### PR TITLE
feat: CS(고객센터) 문의 도메인 기능 구현

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/InquiryController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/InquiryController.java
@@ -1,0 +1,68 @@
+package co.kr.allpick.domain.admin.product.controller;
+
+import co.kr.allpick.domain.admin.product.controller.docs.InquiryControllerDocs;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerResponseDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryCreateRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryResponseDto;
+import co.kr.allpick.domain.admin.product.service.InquiryService;
+import co.kr.allpick.global.response.ApiResponse;
+import co.kr.allpick.global.config.JwtUserInfoDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/inquiries")
+public class InquiryController implements InquiryControllerDocs {
+
+    private final InquiryService inquiryService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<InquiryResponseDto>> createInquiry(
+            @RequestBody @Valid InquiryCreateRequestDto request) {
+        return ApiResponse.success("문의가 등록되었습니다.", inquiryService.createInquiry(request));
+    }
+
+    @Override
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<ApiResponse<InquiryResponseDto>> getInquiryById(
+            @PathVariable("inquiryId") Long inquiryId) {
+        return ApiResponse.success("문의 조회 성공.", inquiryService.getInquiryById(inquiryId));
+    }
+
+    @Override
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<InquiryResponseDto>>> getMyInquiries(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        return ApiResponse.success("내 문의 목록 조회 성공.", inquiryService.getMyInquiries(userInfo.getMemberId()));
+    }
+
+    @Override
+    @GetMapping("/admin")
+    public ResponseEntity<ApiResponse<List<InquiryResponseDto>>> getAllInquiries() {
+        return ApiResponse.success("전체 문의 목록 조회 성공.", inquiryService.getAllInquiries());
+    }
+
+    @Override
+    @PostMapping("/{inquiryId}/answers")
+    public ResponseEntity<ApiResponse<InquiryAnswerResponseDto>> addAnswer(
+            @PathVariable("inquiryId") Long inquiryId,
+            @RequestBody @Valid InquiryAnswerRequestDto request) {
+        return ApiResponse.success("답변이 등록되었습니다.", inquiryService.addAnswer(inquiryId, request));
+    }
+
+    @Override
+    @PatchMapping("/{inquiryId}/cancel")
+    public ResponseEntity<ApiResponse<Void>> cancelInquiry(
+            @PathVariable("inquiryId") Long inquiryId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        inquiryService.cancelInquiry(inquiryId, userInfo.getMemberId());
+        return ApiResponse.success("문의가 취소되었습니다.", null);
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/InquiryController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/InquiryController.java
@@ -53,8 +53,11 @@ public class InquiryController implements InquiryControllerDocs {
     @PostMapping("/{inquiryId}/answers")
     public ResponseEntity<ApiResponse<InquiryAnswerResponseDto>> addAnswer(
             @PathVariable("inquiryId") Long inquiryId,
-            @RequestBody @Valid InquiryAnswerRequestDto request) {
-        return ApiResponse.success("답변이 등록되었습니다.", inquiryService.addAnswer(inquiryId, request));
+            @RequestBody @Valid InquiryAnswerRequestDto request,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        Long adminId  = "ADMIN".equals(userInfo.getRole())  ? userInfo.getMemberId() : null;
+        Long sellerId = "SELLER".equals(userInfo.getRole()) ? userInfo.getMemberId() : null;
+        return ApiResponse.success("답변이 등록되었습니다.", inquiryService.addAnswer(inquiryId, request, adminId, sellerId));
     }
 
     @Override

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/InquiryControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/InquiryControllerDocs.java
@@ -35,10 +35,11 @@ public interface InquiryControllerDocs {
     @Operation(summary = "전체 문의 목록 조회", description = "관리자가 전체 문의 목록을 조회합니다.")
     ResponseEntity<ApiResponse<List<InquiryResponseDto>>> getAllInquiries();
 
-    @Operation(summary = "답변 등록", description = "관리자 또는 판매자가 답변을 등록합니다.")
+    @Operation(summary = "답변 등록", description = "관리자 또는 판매자가 JWT 토큰 기반으로 답변을 등록합니다.")
     ResponseEntity<ApiResponse<InquiryAnswerResponseDto>> addAnswer(
             @Parameter(description = "문의 ID") @PathVariable("inquiryId") Long inquiryId,
-            @RequestBody @Valid InquiryAnswerRequestDto request);
+            @RequestBody @Valid InquiryAnswerRequestDto request,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo);
 
     @Operation(summary = "문의 취소", description = "접수 대기 상태인 문의를 취소합니다.")
     ResponseEntity<ApiResponse<Void>> cancelInquiry(

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/InquiryControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/InquiryControllerDocs.java
@@ -1,0 +1,47 @@
+package co.kr.allpick.domain.admin.product.controller.docs;
+
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerResponseDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryCreateRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryResponseDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import co.kr.allpick.global.config.JwtUserInfoDto;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import java.util.List;
+
+@Tag(name = "Inquiry", description = "문의 API")
+public interface InquiryControllerDocs {
+
+    @Operation(summary = "문의 등록", description = "회원이 문의를 등록합니다.")
+    ResponseEntity<ApiResponse<InquiryResponseDto>> createInquiry(
+            @RequestBody @Valid InquiryCreateRequestDto request);
+
+    @Operation(summary = "문의 상세 조회", description = "문의 ID로 상세 조회합니다.")
+    ResponseEntity<ApiResponse<InquiryResponseDto>> getInquiryById(
+            @Parameter(description = "문의 ID") @PathVariable("inquiryId") Long inquiryId);
+
+    @Operation(summary = "내 문의 목록 조회", description = "JWT 토큰으로 인증된 회원의 문의 목록을 조회합니다.")
+    ResponseEntity<ApiResponse<List<InquiryResponseDto>>> getMyInquiries(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo);
+
+    @Operation(summary = "전체 문의 목록 조회", description = "관리자가 전체 문의 목록을 조회합니다.")
+    ResponseEntity<ApiResponse<List<InquiryResponseDto>>> getAllInquiries();
+
+    @Operation(summary = "답변 등록", description = "관리자 또는 판매자가 답변을 등록합니다.")
+    ResponseEntity<ApiResponse<InquiryAnswerResponseDto>> addAnswer(
+            @Parameter(description = "문의 ID") @PathVariable("inquiryId") Long inquiryId,
+            @RequestBody @Valid InquiryAnswerRequestDto request);
+
+    @Operation(summary = "문의 취소", description = "접수 대기 상태인 문의를 취소합니다.")
+    ResponseEntity<ApiResponse<Void>> cancelInquiry(
+            @Parameter(description = "문의 ID") @PathVariable("inquiryId") Long inquiryId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryAnswerRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryAnswerRequestDto.java
@@ -14,21 +14,15 @@ import lombok.NoArgsConstructor;
 @Schema(description = "답변 요청 DTO")
 public class InquiryAnswerRequestDto {
 
-    @Schema(description = "관리자 ID", example = "1")
-    private Long adminId;
-
-    @Schema(description = "판매자 ID", example = "1")
-    private Long sellerId;
-
     @NotBlank
-    @Schema(description = "답변 내용", example = "정 사이즈 입니다.")
+    @Schema(description = "답변 내용", example = "정 사이즈 입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
     private String content;
 
-    public InquiryAnswer toEntity(Long inquiryId) {
+    public InquiryAnswer toEntity(Long inquiryId, Long adminId, Long sellerId) {
         return InquiryAnswer.builder()
                 .inquiryId(inquiryId)
-                .adminId(this.adminId)
-                .sellerId(this.sellerId)
+                .adminId(adminId)
+                .sellerId(sellerId)
                 .content(this.content)
                 .build();
     }

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryAnswerRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryAnswerRequestDto.java
@@ -1,0 +1,36 @@
+package co.kr.allpick.domain.admin.product.dto;
+
+import co.kr.allpick.domain.admin.product.entity.InquiryAnswer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "답변 요청 DTO")
+public class InquiryAnswerRequestDto {
+
+    @Schema(description = "관리자 ID", example = "1")
+    private Long adminId;
+
+    @Schema(description = "판매자 ID", example = "1")
+    private Long sellerId;
+
+    @NotBlank
+    @Schema(description = "답변 내용", example = "정 사이즈 입니다.")
+    private String content;
+
+    public InquiryAnswer toEntity(Long inquiryId) {
+        return InquiryAnswer.builder()
+                .inquiryId(inquiryId)
+                .adminId(this.adminId)
+                .sellerId(this.sellerId)
+                .content(this.content)
+                .build();
+    }
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryAnswerResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryAnswerResponseDto.java
@@ -1,0 +1,45 @@
+package co.kr.allpick.domain.admin.product.dto;
+
+import co.kr.allpick.domain.admin.product.entity.InquiryAnswer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "답변 응답 DTO")
+public class InquiryAnswerResponseDto {
+
+    @Schema(description = "답변 ID", example = "1")
+    private Long inquiryAnswerId;
+
+    @Schema(description = "문의 ID", example = "10")
+    private Long inquiryId;
+
+    @Schema(description = "관리자 ID", example = "2")
+    private Long adminId;
+
+    @Schema(description = "판매자 ID", example = "13")
+    private Long sellerId;
+
+    @Schema(description = "답변 등록", example = "정 사이즈 입니다.")
+    private String content;
+
+    @Schema(description = "답변 등록 일시", example = "2026-04-22")
+    private LocalDateTime createdAt;
+
+    public static InquiryAnswerResponseDto from(InquiryAnswer answer) {
+        return InquiryAnswerResponseDto.builder()
+                .inquiryAnswerId(answer.getInquiryAnswersId())
+                .inquiryId(answer.getInquiryId())
+                .adminId(answer.getAdminId())
+                .sellerId(answer.getSellerId())
+                .content(answer.getContent())
+                .createdAt(answer.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryCreateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryCreateRequestDto.java
@@ -1,0 +1,52 @@
+package co.kr.allpick.domain.admin.product.dto;
+
+
+import co.kr.allpick.domain.admin.product.entity.Inquiry;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "문의 등록 요청 DTO")
+public class InquiryCreateRequestDto {
+
+    @NotNull
+    @Schema(description = "문의작성 회원 ID", example = "1")
+    private Long memberId;
+
+    @Schema(description = "주문 상품 ID", example = "10")
+    private Long orderItemId;
+
+    @Schema(description = "상품 ID", example = "10")
+    private Long productId;
+
+    @NotNull
+    @Schema(description = "문의 유형", example = "PRODUCT")
+    private Inquiry.InquiryType inquiryType;
+
+    @NotBlank
+    @Schema(description = "문의 제목", example = "상품 사이즈 문의드립니다.")
+    private String title;
+
+    @NotBlank
+    @Schema(description = "문의 내용", example = "정 사이즈인지 궁금합니다.")
+    private String content;
+
+    public Inquiry toEntity() {
+        return Inquiry.builder()
+                .memberId(this.memberId)
+                .orderItemId(this.orderItemId)
+                .productId(this.productId)
+                .inquiryType(this.inquiryType)
+                .title(this.title)
+                .content(this.content)
+                .build();
+    }
+
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/InquiryResponseDto.java
@@ -1,0 +1,63 @@
+package co.kr.allpick.domain.admin.product.dto;
+
+import co.kr.allpick.domain.admin.product.entity.Inquiry;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "문의 응답 DTO")
+public class InquiryResponseDto {
+
+    @Schema(description = "문의 ID", example = "1")
+    private Long inquiryId;
+
+    @Schema(description = "회원 ID", example = "5")
+    private Long memberId;
+
+    @Schema(description = "주문 상품 ID", example = "10")
+    private Long orderItemId;
+
+    @Schema(description = "상품 ID", example = "10")
+    private Long productId;
+
+    @Schema(description = "문의 유형", example = "제품")
+    private Inquiry.InquiryType inquiryType;
+
+    @Schema(description = "문의 제목", example = "사이즈 문의")
+    private String title;
+
+    @Schema(description = "문의 내용", example = "사이즈 문의드립니다.")
+    private String content;
+
+    @Schema(description = "문의 상태", example = "접수 대기")
+    private Inquiry.InquiryStatus status;
+
+    @Schema(description = "문의 등록 일시", example = "2026-04-22")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "답변 목록")
+    private List<InquiryAnswerResponseDto> answers;
+
+    public static InquiryResponseDto from(Inquiry inquiry,
+                                         List<InquiryAnswerResponseDto> answers) {
+        return InquiryResponseDto.builder()
+                .inquiryId(inquiry.getInquiryId())
+                .memberId(inquiry.getMemberId())
+                .orderItemId(inquiry.getOrderItemId())
+                .productId(inquiry.getProductId())
+                .inquiryType(inquiry.getInquiryType())
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .status(inquiry.getStatus())
+                .createdAt(inquiry.getCreatedAt())
+                .answers(answers)
+                .build();
+    }
+
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/Attachment.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/Attachment.java
@@ -1,0 +1,49 @@
+package co.kr.allpick.domain.admin.product.entity;
+
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "attachments")
+@Getter
+@NoArgsConstructor
+public class Attachment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attachment_id")
+    private Long attachmentId;
+
+    @Column(name = "inquiry_id")
+    private Long inquiryId;
+
+    @Column(name = "claim_id")
+    private Long claimId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private TargetType targetType;
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Builder
+    public Attachment(Long inquiryId, Long claimId, TargetType targetType,
+                      String imageUrl, int sortOrder) {
+        this.inquiryId = inquiryId;
+        this.claimId = claimId;
+        this.targetType = targetType;
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+    }
+
+    public enum TargetType {
+        INQUIRY, CLAIM
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/Claim.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/Claim.java
@@ -1,0 +1,20 @@
+package co.kr.allpick.domain.admin.product.entity;
+
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "claims")
+@Getter
+@NoArgsConstructor
+public class Claim extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "claim_id")
+    private Long claimId;
+
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/Claim.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/Claim.java
@@ -2,8 +2,12 @@ package co.kr.allpick.domain.admin.product.entity;
 
 import co.kr.allpick.global.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "claims")
@@ -15,6 +19,95 @@ public class Claim extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "claim_id")
     private Long claimId;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "order_item_id", unique = true)
+    private Long orderItemId;
+
+    @Column(name = "option_id")
+    private Long optionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "claim_type", nullable = false)
+    private ClaimType claimType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ClaimStatus status;
+
+    @Column(name = "reason_code", nullable = false, length = 30)
+    private String reasonCode;
+
+    @Column(name = "detail", columnDefinition = "TEXT")
+    private String detail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pickup_method", nullable = false)
+    private ClaimPickupMethod pickupMethod;
+
+    @Column(name = "reject_reason", columnDefinition = "TEXT")
+    private String rejectReason;
+
+    @Column(name = "exchange_option", length = 100)
+    private String exchangeOption;
+
+    @Column(name = "refund_amount")
+    private BigDecimal refundAmount;
+
+    @Column(name = "shipping_fee")
+    private BigDecimal shippingFee;
+
+    @Column(name = "refunded_at")
+    private LocalDateTime refundedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Builder
+    public Claim(Long memberId,Long orderItemId, Long optionId,
+                 ClaimType claimType, String reasonCode,
+                 String detail, ClaimPickupMethod pickupMethod, String rejectReason,
+                 String exchangeOption, BigDecimal refundAmount, BigDecimal shippingFee) {
+        this.memberId = memberId;
+        this.orderItemId = orderItemId;
+        this.optionId = optionId;
+        this.claimType = claimType;
+        this.status = ClaimStatus.SUBMITTED;
+        this.reasonCode = reasonCode;
+        this.detail = detail;
+        this.pickupMethod = pickupMethod;
+        this.rejectReason = rejectReason;
+        this.exchangeOption = exchangeOption;
+        this.refundAmount = refundAmount;
+        this.shippingFee = shippingFee;
+
+    }
+
+    public void updateStatus(ClaimStatus status) {
+        this.status = status;
+        if (status == ClaimStatus.SUBMITTED) {
+            this.completedAt = LocalDateTime.now();
+        }
+    }
+
+    public void reject(String rejectReason) {
+        this.status = ClaimStatus.REJECTED;
+        this.rejectReason = rejectReason;
+    }
+
+    public enum ClaimType {
+        EXCHANGE, RETURN
+    }
+
+    public enum ClaimStatus {
+        SUBMITTED, IN_PROGRESS, COMPLETED, REJECTED
+    }
+
+    public enum ClaimPickupMethod {
+        COURIER, VISIT
+    }
 
 
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/Inquiry.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/Inquiry.java
@@ -1,0 +1,67 @@
+package co.kr.allpick.domain.admin.product.entity;
+
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "inquiries")
+@Getter
+@NoArgsConstructor
+public class Inquiry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id")
+    private Long inquiryId;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "order_item_id")
+    private Long orderItemId;
+
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inquiry_type", nullable = false)
+    private InquiryType inquiryType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private InquiryStatus status;
+
+    @Builder
+    public Inquiry(Long memberId, Long orderItemId, Long productId, InquiryType inquiryType,
+                   String title, String content) {
+        this.memberId = memberId;
+        this.orderItemId = orderItemId;
+        this.productId = productId;
+        this.inquiryType = inquiryType;
+        this.title = title;
+        this.content = content;
+        this.status = InquiryStatus.PENDING;
+
+    }
+
+    public void updateStatus(InquiryStatus status) {
+        this.status = status;
+    }
+
+    public enum InquiryType {
+        PRODUCT, DELIVERY, PAYMENT, ETC
+    }
+    public enum InquiryStatus {
+        PENDING, PROCESSING, COMPLETED
+    }
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/Inquiry.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/Inquiry.java
@@ -57,11 +57,16 @@ public class Inquiry extends BaseEntity {
         this.status = status;
     }
 
+    public void cancel() {
+        this.status = InquiryStatus.CANCELLED;
+    }
+
     public enum InquiryType {
         PRODUCT, DELIVERY, PAYMENT, ETC
     }
+
     public enum InquiryStatus {
-        PENDING, PROCESSING, COMPLETED
+        PENDING, PROCESSING, COMPLETED, CANCELLED
     }
 
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/InquiryAnswer.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/InquiryAnswer.java
@@ -1,0 +1,43 @@
+package co.kr.allpick.domain.admin.product.entity;
+
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "inquiry_answers")
+@Getter
+@NoArgsConstructor
+public class InquiryAnswer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_answers_id")
+    private Long inquiryAnswersId;
+
+    @Column(name = "inquiry_id", nullable = false)
+    private Long inquiryId;
+
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Column(name = "seller_id")
+    private Long sellerId;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Builder
+    public InquiryAnswer(Long inquiryId, Long adminId, Long sellerId, String content) {
+        this.inquiryId = inquiryId;
+        this.adminId = adminId;
+        this.sellerId = sellerId;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/inquiry.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/inquiry.java
@@ -1,4 +1,0 @@
-package co.kr.allpick.domain.admin.product.entity;
-
-public class inquiry {
-}

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/inquiry.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/inquiry.java
@@ -1,0 +1,4 @@
+package co.kr.allpick.domain.admin.product.entity;
+
+public class inquiry {
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/repository/InquiryAnswerRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/repository/InquiryAnswerRepository.java
@@ -1,0 +1,11 @@
+package co.kr.allpick.domain.admin.product.repository;
+
+import co.kr.allpick.domain.admin.product.entity.InquiryAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface InquiryAnswerRepository extends JpaRepository<InquiryAnswer, Long> {
+
+    List<InquiryAnswer> findByInquiryId(Long inquiryId);
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/repository/InquiryRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/repository/InquiryRepository.java
@@ -1,0 +1,14 @@
+package co.kr.allpick.domain.admin.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import co.kr.allpick.domain.admin.product.entity.Inquiry;
+import java.util.List;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+
+    // 회원별 문의 목록 조회 (삭제 안된 것만)
+    List<Inquiry> findByMemberIdAndDeletedAtIsNull(Long memberId);
+
+    // 전체 문의 목록 조회 (삭제 안된 것만)
+    List<Inquiry> findAllByDeletedAtIsNull();
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/InquiryService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/InquiryService.java
@@ -21,7 +21,7 @@ public interface InquiryService {
     List<InquiryResponseDto> getAllInquiries();
 
     // 답변 등록
-    InquiryAnswerResponseDto addAnswer(Long inquiryId, InquiryAnswerRequestDto request);
+    InquiryAnswerResponseDto addAnswer(Long inquiryId, InquiryAnswerRequestDto request, Long adminId, Long sellerId);
 
     // 문의 취소
     void cancelInquiry(Long inquiryId, Long memberId);

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/InquiryService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/InquiryService.java
@@ -1,0 +1,29 @@
+package co.kr.allpick.domain.admin.product.service;
+
+import co.kr.allpick.domain.admin.product.dto.InquiryResponseDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryCreateRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerResponseDto;
+import java.util.List;
+
+public interface InquiryService {
+
+    // 문의 등록
+    InquiryResponseDto createInquiry(InquiryCreateRequestDto request);
+
+    // 문의 상세 조회
+    InquiryResponseDto getInquiryById(Long inquiryId);
+
+    // 내 문의 목록 조회
+    List<InquiryResponseDto> getMyInquiries(Long memberId);
+
+    // 전체 문의 목록 조회 (관리자)
+    List<InquiryResponseDto> getAllInquiries();
+
+    // 답변 등록
+    InquiryAnswerResponseDto addAnswer(Long inquiryId, InquiryAnswerRequestDto request);
+
+    // 문의 취소
+    void cancelInquiry(Long inquiryId, Long memberId);
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
@@ -1,0 +1,98 @@
+package co.kr.allpick.domain.admin.product.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+import co.kr.allpick.domain.admin.product.dto.InquiryCreateRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryResponseDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerResponseDto;
+import co.kr.allpick.domain.admin.product.entity.Inquiry;
+import co.kr.allpick.domain.admin.product.entity.InquiryAnswer;
+import co.kr.allpick.domain.admin.product.repository.InquiryRepository;
+import co.kr.allpick.domain.admin.product.repository.InquiryAnswerRepository;
+import co.kr.allpick.domain.admin.product.service.InquiryService;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryServiceImpl implements InquiryService {
+
+    private static final Logger logger = LogManager.getLogger(InquiryServiceImpl.class);
+
+    private final InquiryRepository inquiryRepository;
+    private final InquiryAnswerRepository inquiryAnswerRepository;
+
+    // 1. 문의 등록
+    @Override
+    @Transactional
+    public InquiryResponseDto createInquiry(InquiryCreateRequestDto request) {
+        logger.info("[InquiryService] 문의 등록 - memberId: {}", request.getMemberId());
+        Inquiry inquiry = inquiryRepository.save(request.toEntity());
+        return InquiryResponseDto.from(inquiry, List.of());
+    }
+
+    // 2. 문의 상세 조회
+    @Override
+    @Transactional(readOnly = true)
+    public InquiryResponseDto getInquiryById(Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        List<InquiryAnswerResponseDto> answers = inquiryAnswerRepository
+                .findByInquiryId(inquiryId)
+                .stream()
+                .map(InquiryAnswerResponseDto::from)
+                .toList();
+        return InquiryResponseDto.from(inquiry, answers);
+    }
+
+    // 3. 내 문의 목록 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<InquiryResponseDto> getMyInquiries(Long memberId) {
+        return inquiryRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .stream()
+                .map(inquiry -> InquiryResponseDto.from(inquiry, List.of()))
+                .toList();
+    }
+
+    // 4. 전체 문의 목록 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<InquiryResponseDto> getAllInquiries() {
+        return inquiryRepository.findAllByDeletedAtIsNull()
+                .stream()
+                .map(inquiry -> InquiryResponseDto.from(inquiry, List.of()))
+                .toList();
+    }
+
+    // 5. 답변 등록
+    @Override
+    @Transactional
+    public InquiryAnswerResponseDto addAnswer(Long inquiryId, InquiryAnswerRequestDto request) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        inquiry.updateStatus(Inquiry.InquiryStatus.PROCESSING);
+        InquiryAnswer answer = inquiryAnswerRepository.save(request.toEntity(inquiryId));
+        return InquiryAnswerResponseDto.from(answer);
+    }
+
+    // 6. 문의 취소
+    @Override
+    @Transactional
+    public void cancelInquiry(Long inquiryId, Long memberId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        if (!inquiry.getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.INQUIRY_UNAUTHORIZED);
+        }
+        if (inquiry.getStatus() != Inquiry.InquiryStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INQUIRY_CANNOT_CANCEL);
+        }
+        inquiry.cancel();
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
@@ -73,11 +73,11 @@ public class InquiryServiceImpl implements InquiryService {
     // 5. 답변 등록
     @Override
     @Transactional
-    public InquiryAnswerResponseDto addAnswer(Long inquiryId, InquiryAnswerRequestDto request) {
+    public InquiryAnswerResponseDto addAnswer(Long inquiryId, InquiryAnswerRequestDto request, Long adminId, Long sellerId) {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
         inquiry.updateStatus(Inquiry.InquiryStatus.PROCESSING);
-        InquiryAnswer answer = inquiryAnswerRepository.save(request.toEntity(inquiryId));
+        InquiryAnswer answer = inquiryAnswerRepository.save(request.toEntity(inquiryId, adminId, sellerId));
         return InquiryAnswerResponseDto.from(answer);
     }
 

--- a/src/main/java/co/kr/allpick/global/common/BaseEntity.java
+++ b/src/main/java/co/kr/allpick/global/common/BaseEntity.java
@@ -24,4 +24,8 @@ public abstract class BaseEntity {
     private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt;
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -20,7 +20,19 @@ public enum ErrorCode {
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "COUPON_NOT_FOUND", "쿠폰을 찾을 수 없습니다."),
     COUPON_CODE_DUPLICATE(HttpStatus.BAD_REQUEST, "COUPON_CODE_DUPLICATE", "이미 존재하는 쿠폰 코드입니다."),
     COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_USED", "이미 사용된 쿠폰입니다."),
-    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "만료된 쿠폰입니다.");
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "만료된 쿠폰입니다."),
+
+    // Inquiry
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY_NOT_FOUND", "문의를 찾을 수 없습니다."),
+    INQUIRY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "INQUIRY_ALREADY_DELETED", "이미 삭제된 문의입니다."),
+    INQUIRY_ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY_ANSWER_NOT_FOUND", "문의 답변을 찾을 수 없습니다."),
+    INQUIRY_UNAUTHORIZED(HttpStatus.FORBIDDEN, "INQUIRY_UNAUTHORIZED", "해당 문의에 대한 권한이 없습니다."),
+
+    // Claim
+    CLAIM_NOT_FOUND(HttpStatus.NOT_FOUND, "CLAIM_NOT_FOUND", "클레임을 찾을 수 없습니다."),
+    CLAIM_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "CLAIM_ALREADY_DELETED", "이미 삭제된 클레임입니다."),
+    CLAIM_INVALID_STATUS(HttpStatus.BAD_REQUEST, "CLAIM_INVALID_STATUS", "유효하지 않은 클레임 상태입니다."),
+    CLAIM_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "CLAIM_ALREADY_COMPLETED", "이미 처리 완료된 클레임입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     INQUIRY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "INQUIRY_ALREADY_DELETED", "이미 삭제된 문의입니다."),
     INQUIRY_ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY_ANSWER_NOT_FOUND", "문의 답변을 찾을 수 없습니다."),
     INQUIRY_UNAUTHORIZED(HttpStatus.FORBIDDEN, "INQUIRY_UNAUTHORIZED", "해당 문의에 대한 권한이 없습니다."),
+    // 문의 접수 대기 시 취소 가능 에러코드 추가
+    INQUIRY_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "INQUIRY_CANNOT_CANCEL", "접수 대기 상태에서만 취소 가능합니다."),
 
     // Claim
     CLAIM_NOT_FOUND(HttpStatus.NOT_FOUND, "CLAIM_NOT_FOUND", "클레임을 찾을 수 없습니다."),

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -21,7 +21,6 @@ public enum ErrorCode {
     COUPON_CODE_DUPLICATE(HttpStatus.BAD_REQUEST, "COUPON_CODE_DUPLICATE", "이미 존재하는 쿠폰 코드입니다."),
     COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_USED", "이미 사용된 쿠폰입니다."),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "만료된 쿠폰입니다."),
-<<<<<<< HEAD
 
     // Inquiry
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY_NOT_FOUND", "문의를 찾을 수 없습니다."),
@@ -33,9 +32,7 @@ public enum ErrorCode {
     CLAIM_NOT_FOUND(HttpStatus.NOT_FOUND, "CLAIM_NOT_FOUND", "클레임을 찾을 수 없습니다."),
     CLAIM_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "CLAIM_ALREADY_DELETED", "이미 삭제된 클레임입니다."),
     CLAIM_INVALID_STATUS(HttpStatus.BAD_REQUEST, "CLAIM_INVALID_STATUS", "유효하지 않은 클레임 상태입니다."),
-    CLAIM_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "CLAIM_ALREADY_COMPLETED", "이미 처리 완료된 클레임입니다.");
-=======
->>>>>>> develop
+    CLAIM_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "CLAIM_ALREADY_COMPLETED", "이미 처리 완료된 클레임입니다."),
 
     NOT_SELLER(HttpStatus.FORBIDDEN, "NOT_SELLER", "판매자 권한이 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImplTest.java
@@ -179,7 +179,7 @@ class InquiryServiceImplTest {
                 .content("문의 내용")
                 .build();
 
-        InquiryAnswerRequestDto request = new InquiryAnswerRequestDto(2L, null, "정 사이즈 입니다.");
+        InquiryAnswerRequestDto request = new InquiryAnswerRequestDto("정 사이즈 입니다.");
 
         InquiryAnswer mockAnswer = InquiryAnswer.builder()
                 .inquiryId(inquiryId)
@@ -191,7 +191,7 @@ class InquiryServiceImplTest {
         when(inquiryAnswerRepository.save(any(InquiryAnswer.class))).thenReturn(mockAnswer);
 
         // when
-        InquiryAnswerResponseDto result = inquiryService.addAnswer(inquiryId, request);
+        InquiryAnswerResponseDto result = inquiryService.addAnswer(inquiryId, request, 2L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -204,12 +204,12 @@ class InquiryServiceImplTest {
     @DisplayName("답변 등록 실패 - 문의 없음")
     void 답변_등록_실패_문의없음() {
         // given
-        InquiryAnswerRequestDto request = new InquiryAnswerRequestDto(2L, null, "답변 내용");
+        InquiryAnswerRequestDto request = new InquiryAnswerRequestDto("답변 내용");
 
         when(inquiryRepository.findById(999L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> inquiryService.addAnswer(999L, request))
+        assertThatThrownBy(() -> inquiryService.addAnswer(999L, request, 2L, null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.INQUIRY_NOT_FOUND.getMessage());
     }

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImplTest.java
@@ -1,0 +1,295 @@
+package co.kr.allpick.domain.admin.product.service.impl;
+
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryAnswerResponseDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryCreateRequestDto;
+import co.kr.allpick.domain.admin.product.dto.InquiryResponseDto;
+import co.kr.allpick.domain.admin.product.entity.Inquiry;
+import co.kr.allpick.domain.admin.product.entity.InquiryAnswer;
+import co.kr.allpick.domain.admin.product.repository.InquiryAnswerRepository;
+import co.kr.allpick.domain.admin.product.repository.InquiryRepository;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InquiryServiceImplTest {
+
+    @Mock
+    InquiryRepository inquiryRepository;
+
+    @Mock
+    InquiryAnswerRepository inquiryAnswerRepository;
+
+    @InjectMocks
+    InquiryServiceImpl inquiryService;
+
+    @Test
+    @DisplayName("문의 등록 성공")
+    void 문의_등록_성공() {
+        // given
+        InquiryCreateRequestDto request = new InquiryCreateRequestDto(
+                1L, 10L, 5L, Inquiry.InquiryType.PRODUCT,
+                "사이즈 문의드립니다.", "정 사이즈인지 궁금합니다.");
+
+        Inquiry mockInquiry = Inquiry.builder()
+                .memberId(1L)
+                .orderItemId(10L)
+                .productId(5L)
+                .inquiryType(Inquiry.InquiryType.PRODUCT)
+                .title("사이즈 문의드립니다.")
+                .content("정 사이즈인지 궁금합니다.")
+                .build();
+
+        when(inquiryRepository.save(any(Inquiry.class))).thenReturn(mockInquiry);
+
+        // when
+        InquiryResponseDto result = inquiryService.createInquiry(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMemberId()).isEqualTo(1L);
+        assertThat(result.getTitle()).isEqualTo("사이즈 문의드립니다.");
+        assertThat(result.getStatus()).isEqualTo(Inquiry.InquiryStatus.PENDING);
+        assertThat(result.getAnswers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("문의 상세 조회 성공")
+    void 문의_상세_조회_성공() {
+        // given
+        Long inquiryId = 1L;
+
+        Inquiry mockInquiry = Inquiry.builder()
+                .memberId(1L)
+                .orderItemId(10L)
+                .productId(5L)
+                .inquiryType(Inquiry.InquiryType.DELIVERY)
+                .title("배송 관련 문의")
+                .content("배송이 언제 오나요?")
+                .build();
+
+        InquiryAnswer mockAnswer = InquiryAnswer.builder()
+                .inquiryId(inquiryId)
+                .adminId(2L)
+                .content("3~5일 이내 도착 예정입니다.")
+                .build();
+
+        when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(mockInquiry));
+        when(inquiryAnswerRepository.findByInquiryId(inquiryId)).thenReturn(List.of(mockAnswer));
+
+        // when
+        InquiryResponseDto result = inquiryService.getInquiryById(inquiryId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("배송 관련 문의");
+        assertThat(result.getAnswers()).hasSize(1);
+        assertThat(result.getAnswers().get(0).getContent()).isEqualTo("3~5일 이내 도착 예정입니다.");
+    }
+
+    @Test
+    @DisplayName("문의 상세 조회 실패 - 문의 없음")
+    void 문의_상세_조회_실패_문의없음() {
+        // given
+        when(inquiryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> inquiryService.getInquiryById(999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INQUIRY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("내 문의 목록 조회 성공")
+    void 내_문의_목록_조회_성공() {
+        // given
+        Long memberId = 1L;
+
+        Inquiry mockInquiry1 = Inquiry.builder()
+                .memberId(memberId)
+                .inquiryType(Inquiry.InquiryType.PRODUCT)
+                .title("상품 문의1")
+                .content("내용1")
+                .build();
+
+        Inquiry mockInquiry2 = Inquiry.builder()
+                .memberId(memberId)
+                .inquiryType(Inquiry.InquiryType.PAYMENT)
+                .title("결제 문의")
+                .content("결제 관련 내용")
+                .build();
+
+        when(inquiryRepository.findByMemberIdAndDeletedAtIsNull(memberId))
+                .thenReturn(List.of(mockInquiry1, mockInquiry2));
+
+        // when
+        List<InquiryResponseDto> result = inquiryService.getMyInquiries(memberId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("상품 문의1");
+        assertThat(result.get(1).getInquiryType()).isEqualTo(Inquiry.InquiryType.PAYMENT);
+    }
+
+    @Test
+    @DisplayName("전체 문의 목록 조회 성공")
+    void 전체_문의_목록_조회_성공() {
+        // given
+        Inquiry mockInquiry = Inquiry.builder()
+                .memberId(1L)
+                .inquiryType(Inquiry.InquiryType.ETC)
+                .title("기타 문의")
+                .content("기타 내용")
+                .build();
+
+        when(inquiryRepository.findAllByDeletedAtIsNull()).thenReturn(List.of(mockInquiry));
+
+        // when
+        List<InquiryResponseDto> result = inquiryService.getAllInquiries();
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getInquiryType()).isEqualTo(Inquiry.InquiryType.ETC);
+    }
+
+    @Test
+    @DisplayName("답변 등록 성공")
+    void 답변_등록_성공() {
+        // given
+        Long inquiryId = 1L;
+
+        Inquiry mockInquiry = Inquiry.builder()
+                .memberId(1L)
+                .inquiryType(Inquiry.InquiryType.PRODUCT)
+                .title("상품 문의")
+                .content("문의 내용")
+                .build();
+
+        InquiryAnswerRequestDto request = new InquiryAnswerRequestDto(2L, null, "정 사이즈 입니다.");
+
+        InquiryAnswer mockAnswer = InquiryAnswer.builder()
+                .inquiryId(inquiryId)
+                .adminId(2L)
+                .content("정 사이즈 입니다.")
+                .build();
+
+        when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(mockInquiry));
+        when(inquiryAnswerRepository.save(any(InquiryAnswer.class))).thenReturn(mockAnswer);
+
+        // when
+        InquiryAnswerResponseDto result = inquiryService.addAnswer(inquiryId, request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEqualTo("정 사이즈 입니다.");
+        assertThat(result.getAdminId()).isEqualTo(2L);
+        assertThat(mockInquiry.getStatus()).isEqualTo(Inquiry.InquiryStatus.PROCESSING);
+    }
+
+    @Test
+    @DisplayName("답변 등록 실패 - 문의 없음")
+    void 답변_등록_실패_문의없음() {
+        // given
+        InquiryAnswerRequestDto request = new InquiryAnswerRequestDto(2L, null, "답변 내용");
+
+        when(inquiryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> inquiryService.addAnswer(999L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INQUIRY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("문의 취소 성공")
+    void 문의_취소_성공() {
+        // given
+        Long inquiryId = 1L;
+        Long memberId = 1L;
+
+        Inquiry mockInquiry = Inquiry.builder()
+                .memberId(memberId)
+                .inquiryType(Inquiry.InquiryType.PRODUCT)
+                .title("취소할 문의")
+                .content("내용")
+                .build();
+
+        when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(mockInquiry));
+
+        // when
+        inquiryService.cancelInquiry(inquiryId, memberId);
+
+        // then
+        assertThat(mockInquiry.getStatus()).isEqualTo(Inquiry.InquiryStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("문의 취소 실패 - 문의 없음")
+    void 문의_취소_실패_문의없음() {
+        // given
+        when(inquiryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> inquiryService.cancelInquiry(999L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INQUIRY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("문의 취소 실패 - 권한 없음")
+    void 문의_취소_실패_권한없음() {
+        // given
+        Long inquiryId = 1L;
+
+        Inquiry mockInquiry = Inquiry.builder()
+                .memberId(1L)
+                .inquiryType(Inquiry.InquiryType.PRODUCT)
+                .title("문의 제목")
+                .content("내용")
+                .build();
+
+        when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(mockInquiry));
+
+        // when & then
+        assertThatThrownBy(() -> inquiryService.cancelInquiry(inquiryId, 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INQUIRY_UNAUTHORIZED.getMessage());
+    }
+
+    @Test
+    @DisplayName("문의 취소 실패 - 접수 대기 상태가 아님")
+    void 문의_취소_실패_취소불가상태() {
+        // given
+        Long inquiryId = 1L;
+        Long memberId = 1L;
+
+        Inquiry mockInquiry = Inquiry.builder()
+                .memberId(memberId)
+                .inquiryType(Inquiry.InquiryType.PRODUCT)
+                .title("문의 제목")
+                .content("내용")
+                .build();
+        mockInquiry.updateStatus(Inquiry.InquiryStatus.PROCESSING);
+
+        when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(mockInquiry));
+
+        // when & then
+        assertThatThrownBy(() -> inquiryService.cancelInquiry(inquiryId, memberId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INQUIRY_CANNOT_CANCEL.getMessage());
+    }
+}


### PR DESCRIPTION
## 개요
고객센터 패키지 구조를 분리하고, 1:1 문의(Inquiry) 도메인의 엔티티 및 전체 CRUD 기능을 구현했습니다.

---

## 주요 변경 사항

### 1. CS 패키지 구조 분리
- `domain/admin/product` 하위에 CS 관련 패키지 구조 초기 세팅

### 2. 엔티티 생성
| 엔티티 | 설명 |
|---|---|
| `Inquiry` | 1:1 문의 (타입: PRODUCT/DELIVERY/PAYMENT/ETC, 상태: PENDING/PROCESSING/COMPLETED/CANCELLED) |
| `InquiryAnswer` | 문의 답변 (관리자/판매자 답변 지원) |
| `Claim` | 교환/반품 클레임 (타입: EXCHANGE/RETURN, 상태: SUBMITTED/IN_PROGRESS/COMPLETED/REJECTED) |
| `Attachment` | 문의·클레임 공통 첨부파일 (INQUIRY/CLAIM 타입 구분) |

### 3. 문의(Inquiry) 도메인 기능 구현
- **Repository**: `InquiryRepository`, `InquiryAnswerRepository`
- **DTO**: 등록 요청 / 응답 / 답변 요청·응답 DTO
- **Service / ServiceImpl**: 비즈니스 로직 구현
- **Controller**: REST API 엔드포인트 구현

### 4. API 엔드포인트

| Method | URL | 설명 | 인증 |
|---|---|---|---|
| `POST` | `/api/inquiries` | 문의 등록 | - |
| `GET` | `/api/inquiries/{inquiryId}` | 문의 단건 조회 | - |
| `GET` | `/api/inquiries/my` | 내 문의 목록 조회 | JWT |
| `GET` | `/api/inquiries/admin` | 전체 문의 목록 조회 (관리자) | - |
| `POST` | `/api/inquiries/{inquiryId}/answers` | 답변 등록 | - |
| `PATCH` | `/api/inquiries/{inquiryId}/cancel` | 문의 취소 | JWT |

### 5. 기타
- `PENDING` 상태에서만 문의 취소 가능하도록 상태 검증 처리
- `ErrorCode`에 Inquiry/Claim 관련 에러 코드 추가
- `InquiryControllerDocs` (Swagger 문서화 인터페이스) 추가
- `Swagger` 테스트 완료