### PR TITLE
fix:스웨거 order + coupon 403에러 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      # 3. Gradle 빌드 (테스트 제외)
+      # 3. Gradle 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # 4. Gradle 빌드 (테스트 제외)
       - name: Build with Gradle
         run: ./gradlew clean build -x test
         env:
@@ -30,7 +34,7 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           JWT_EXPIRATION_TIME: ${{ secrets.JWT_EXPIRATION_TIME }}
 
-      # 4. AWS 인증
+      # 5. AWS 인증
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -38,12 +42,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # 5. S3에 jar 업로드
+      # 6. S3에 jar 업로드
       - name: Upload jar to S3
         run: |
           aws s3 cp build/libs/*.jar s3://${{ secrets.BACKEND_S3_BUCKET_NAME }}/deploy/app.jar
 
-      # 6. EC2에서 배포 (SSM)
+      # 7. EC2에서 배포 (SSM)
       - name: Deploy to EC2 via SSM
         run: |
           aws ssm send-command \

--- a/src/main/java/co/kr/allpick/domain/member/membership/controller/docs/MembershipControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/member/membership/controller/docs/MembershipControllerDocs.java
@@ -11,6 +11,17 @@ import java.util.List;
 @Tag(name = "Membership", description = "멤버십 등급 API")
 public interface MembershipControllerDocs {
 
-    @Operation(summary = "등급 변경 이력 조회", description = "특정 회원의 멤버십 등급 변경 이력을 조회합니다.")
-    ResponseEntity<ApiResponse<List<MembershipHistoryResponseDto>>> getMembershipHistory(Long memberId);
+	@Operation(summary = "등급 변경 이력 조회", description = "특정 회원의 멤버십 등급 변경 이력을 조회합니다.")
+	@io.swagger.v3.oas.annotations.responses.ApiResponses({
+	    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+	        responseCode = "200", description = "조회 성공"
+	    ),
+	    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+	        responseCode = "403", description = "인증 정보 없음 또는 권한 없음"
+	    ),
+	    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+	        responseCode = "404", description = "존재하지 않는 회원"
+	    )
+	})
+	ResponseEntity<ApiResponse<List<MembershipHistoryResponseDto>>> getMembershipHistory(Long memberId);
 }

--- a/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
+++ b/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
@@ -24,11 +24,10 @@ public class SecurityConfig {
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                .requestMatchers("/api/membership/**").authenticated()
-                .anyRequest().authenticated()
-            )
+            	    .requestMatchers("/api/auth/**").permitAll()
+            	    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+            	    .anyRequest().authenticated()
+            	)
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/co/kr/allpick/global/filter/JwtAuthFilter.java
+++ b/src/main/java/co/kr/allpick/global/filter/JwtAuthFilter.java
@@ -38,9 +38,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 || path.startsWith("/api/auth/login")
                 || path.startsWith("/api/auth/signup")
                 || path.startsWith("/api/members/login")
-                || path.startsWith("/api/members/signup")
-                || path.startsWith("/api/orders")
-                || path.startsWith("/api/coupons")) {
+                || path.startsWith("/api/members/signup")) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
## 개요
- 스웨거에서 토큰 받아 로그인시 다른 API 테스트 할때 403에러가 나던 상황 해결

---

## 작업 내용
- [ ] 기능 추가
- [v] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- SecurityConfig + JwtAuthFilter
---

## 관련 이슈
- close #13 

---

## 변경 전 / 후
### Before
- 기존엔 스웨거에서 Token을 받아 로그인을 해도 API 테스트 시 403에러가 발생했었다.

### After
- JwtAuthFilter에서 /api/orders, /api/coupons 경로를 토큰 검증 전에 통과시켜 SecurityContextHolder에 인증 정보가 등록되지 않던 문제를 수정했습니다.