### PR TITLE
feat: AdminServiceImpl 구현

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
@@ -1,7 +1,6 @@
 package co.kr.allpick.domain.admin.dto;
 
 import co.kr.allpick.domain.admin.entity.Admin;
-import co.kr.allpick.domain.admin.service.AdminServiceImpl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
@@ -1,6 +1,7 @@
 package co.kr.allpick.domain.admin.dto;
 
 import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.admin.service.AdminServiceImpl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -32,5 +33,19 @@ public class AdminCreateRequestDto {
     @Schema(description = "관리자 연락처", example = "01012341234")
     @Pattern(regexp = "SUPER_ADMIN|CS_ADMIN", message ="role은 SUPER_ADMIN 또는 CS_ADMIN이어야 합니다.")
     private String role;
+
+
+  public Admin toEntity(String encodedPassword){
+      return Admin.builder()
+              .adminName(this.getAdminName())
+              .email(this.getEmail())
+              .password( encodedPassword) //암호화된 비밀번호 저장
+              .adminPhone(this.getAdminPhone())
+              .role(Admin.AdminRole.valueOf(this.getRole()))
+              .status(Admin.AdminStatus.ACTIVE)
+              .build();
+
+
+  }
 }
 

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
@@ -1,6 +1,9 @@
 package co.kr.allpick.domain.admin.dto;
 
 import co.kr.allpick.domain.admin.entity.Admin;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +13,24 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AdminCreateRequestDto {
 
+    @Schema(description = "이메일", example = "test@test.com")
+    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
+
+    @Schema(description = "비밀번호", example = "QWWEqwer1234!@#$")
+    @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
+
+    @Schema(description = "관리자 이름", example = "홍길동")
+    @NotBlank(message = "관리자 이름은 필수입니다.")
     private String adminName;
+
+    @Schema(description = "관리자 연락처", example = "01012341234")
+    @NotBlank(message = "전화번호는 필수입니다.")
     private String adminPhone;
+
+    @Schema(description = "관리자 연락처", example = "01012341234")
+    @Pattern(regexp = "SUPER_ADMIN|CS_ADMIN", message ="role은 SUPER_ADMIN 또는 CS_ADMIN이어야 합니다.")
     private String role;
 }
 

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminCreateRequestDto.java
@@ -1,0 +1,19 @@
+package co.kr.allpick.domain.admin.dto;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminCreateRequestDto {
+
+    private String email;
+    private String password;
+    private String adminName;
+    private String adminPhone;
+    private String role;
+}
+

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginRequestDto.java
@@ -1,15 +1,23 @@
 package co.kr.allpick.domain.admin.dto;
 
-
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "관리자 로그인 요청 DTO")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class AdminLoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Schema(description = "이메일", example = "admin@allpick.com")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "비밀번호", example = "Admin1234!@")
     private String password;
 
 }

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginRequestDto.java
@@ -1,0 +1,15 @@
+package co.kr.allpick.domain.admin.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminLoginRequestDto {
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginRequestDto.java
@@ -13,11 +13,11 @@ import lombok.NoArgsConstructor;
 public class AdminLoginRequestDto {
 
     @NotBlank(message = "이메일은 필수입니다.")
-    @Schema(description = "이메일", example = "admin@allpick.com")
+    @Schema(description = "이메일", example = "admin@allpick.com", requiredMode = Schema.RequiredMode.REQUIRED)
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
-    @Schema(description = "비밀번호", example = "Admin1234!@")
+    @Schema(description = "비밀번호", example = "Admin1234!@", requiredMode = Schema.RequiredMode.REQUIRED)
     private String password;
 
 }

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginResponseDto.java
@@ -1,6 +1,7 @@
 package co.kr.allpick.domain.admin.dto;
 
 
+import co.kr.allpick.domain.admin.entity.Admin;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +12,12 @@ public class AdminLoginResponseDto {
     private String adminName;
     private String token;
     private String role;
+
+    public static AdminLoginResponseDto from(Admin admin, String token){
+        return AdminLoginResponseDto.builder()
+                .adminName(admin.getAdminName())
+                .role(admin.getRole().name())
+                .token(token)
+                .build();
+    }
 }

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginResponseDto.java
@@ -1,0 +1,14 @@
+package co.kr.allpick.domain.admin.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminLoginResponseDto {
+
+    private String adminName;
+    private String token;
+    private String role;
+}

--- a/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/dto/AdminLoginResponseDto.java
@@ -1,6 +1,5 @@
 package co.kr.allpick.domain.admin.dto;
 
-
 import co.kr.allpick.domain.admin.entity.Admin;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,12 +10,10 @@ public class AdminLoginResponseDto {
 
     private String adminName;
     private String token;
-    private String role;
 
     public static AdminLoginResponseDto from(Admin admin, String token){
         return AdminLoginResponseDto.builder()
                 .adminName(admin.getAdminName())
-                .role(admin.getRole().name())
                 .token(token)
                 .build();
     }

--- a/src/main/java/co/kr/allpick/domain/admin/entity/Admin.java
+++ b/src/main/java/co/kr/allpick/domain/admin/entity/Admin.java
@@ -1,0 +1,73 @@
+package co.kr.allpick.domain.admin.entity;
+
+
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "admins")
+@Getter
+@NoArgsConstructor
+public class Admin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name ="admin_id")
+    private Long adminId;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String adminName;
+
+    @Column(nullable = false)
+    private String adminPhone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable= false)
+    private AdminRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable= false)
+    private AdminStatus status;
+
+    private LocalDateTime lastLoginAt;
+
+
+    @Builder
+    public Admin( String email, String password, String adminName
+            , String adminPhone, AdminRole role, AdminStatus status) {
+        this.email = email;
+        this.password = password;
+        this.adminName =adminName;
+        this.adminPhone = adminPhone;
+        this.role = role;
+        this.status =status;
+    }
+
+
+    public void updateStatus(AdminStatus status){
+        this.status =status;
+    }
+
+    public void updateLastLoginAt(LocalDateTime lastLoginAt){
+        this.lastLoginAt =lastLoginAt;
+    }
+
+
+    public enum AdminRole{
+        SUPER_ADMIN, CS_ADMIN
+    }
+
+    public enum AdminStatus{
+        ACTIVE, BLOCKED
+    }
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/entity/Admin.java
+++ b/src/main/java/co/kr/allpick/domain/admin/entity/Admin.java
@@ -27,26 +27,27 @@ public class Admin extends BaseEntity {
     @Column(name ="admin_id")
     private Long adminId;
 
-    @Column(nullable = false, unique = true)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(nullable = false)
+    @Column(name = "admin_name", nullable = false)
     private String adminName;
 
-    @Column(nullable = false)
+    @Column(name = "admin_phone", nullable = false)
     private String adminPhone;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable= false)
+    @Column(name = "role", nullable = false)
     private AdminRole role;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable= false)
+    @Column(name = "status", nullable = false)
     private AdminStatus status;
 
+    @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
 
 

--- a/src/main/java/co/kr/allpick/domain/admin/entity/Admin.java
+++ b/src/main/java/co/kr/allpick/domain/admin/entity/Admin.java
@@ -2,8 +2,17 @@ package co.kr.allpick.domain.admin.entity;
 
 
 import co.kr.allpick.global.common.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/co/kr/allpick/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,12 @@
+package co.kr.allpick.domain.admin.repository;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByEmail(String email);
+}
+

--- a/src/main/java/co/kr/allpick/domain/admin/service/AdminService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/AdminService.java
@@ -1,4 +1,15 @@
 package co.kr.allpick.domain.admin.service;
 
-public class AdminService {
+import co.kr.allpick.domain.admin.dto.AdminCreateRequestDto;
+import co.kr.allpick.domain.admin.dto.AdminLoginRequestDto;
+import co.kr.allpick.domain.admin.dto.AdminLoginResponseDto;
+import co.kr.allpick.domain.admin.entity.Admin;
+
+public interface AdminService {
+
+    AdminLoginResponseDto adminLogin(AdminLoginRequestDto adminLoginRequestDto);
+
+    void createAdmin(AdminCreateRequestDto adminCreateRequestDto);
+
+    void  updateStatus(Long adminId, Admin.AdminStatus status);
 }

--- a/src/main/java/co/kr/allpick/domain/admin/service/AdminService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/AdminService.java
@@ -1,0 +1,4 @@
+package co.kr.allpick.domain.admin.service;
+
+public class AdminService {
+}

--- a/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
@@ -60,15 +60,8 @@ public class AdminServiceImpl implements AdminService {
         //1. 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(adminCreateRequestDto.getPassword());
 
-        //2. Admin 객체 생성
-        Admin admin = Admin.builder()
-                .adminName(adminCreateRequestDto.getAdminName())
-                .email(adminCreateRequestDto.getEmail())
-                .password(encodedPassword) //암호화된 비밀번호 저장
-                .adminPhone(adminCreateRequestDto.getAdminPhone())
-                .role(Admin.AdminRole.valueOf(adminCreateRequestDto.getRole()))
-                .status(Admin.AdminStatus.ACTIVE)
-                .build();
+        //2. Admin 객체 생성(toEntity()패턴)
+        Admin admin = adminCreateRequestDto.toEntity(encodedPassword);
 
         adminRepository.save(admin);
 

--- a/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
@@ -1,0 +1,12 @@
+package co.kr.allpick.domain.admin.service;
+
+
+import co.kr.allpick.domain.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminRepository {
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
@@ -1,12 +1,84 @@
 package co.kr.allpick.domain.admin.service;
 
 
+import co.kr.allpick.domain.admin.dto.AdminCreateRequestDto;
+import co.kr.allpick.domain.admin.dto.AdminLoginRequestDto;
+import co.kr.allpick.domain.admin.dto.AdminLoginResponseDto;
+import co.kr.allpick.domain.admin.entity.Admin;
 import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.global.config.JwtProvider;
+import co.kr.allpick.global.config.JwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-public class AdminServiceImpl implements AdminRepository {
+public class AdminServiceImpl implements AdminService {
 
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public AdminLoginResponseDto adminLogin(AdminLoginRequestDto adminLoginRequestDto) {
+
+
+        Admin admin =
+                adminRepository.findByEmail(adminLoginRequestDto.getEmail())
+                        .orElseThrow(() -> new
+                                BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (!passwordEncoder.matches(adminLoginRequestDto.getPassword(), admin.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        JwtUserInfoDto jwtUserInfoDto = new JwtUserInfoDto(
+                admin.getAdminId(),
+                admin.getEmail(),
+                admin.getRole().name()
+        );
+
+        String token = jwtProvider.createToken(jwtUserInfoDto);
+
+
+        return AdminLoginResponseDto.builder()
+                .adminName(admin.getAdminName())
+                .role(admin.getRole().name())
+                .token(token)
+                .build();
+
+    }
+
+    @Override
+    public void createAdmin(AdminCreateRequestDto adminCreateRequestDto) {
+
+        //1. 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(adminCreateRequestDto.getPassword());
+
+        //2. Admin 객체 생성
+        Admin admin = Admin.builder()
+                .adminName(adminCreateRequestDto.getAdminName())
+                .email(adminCreateRequestDto.getEmail())
+                .password(encodedPassword) //암호화된 비밀번호 저장
+                .adminPhone(adminCreateRequestDto.getAdminPhone())
+                .role(Admin.AdminRole.valueOf(adminCreateRequestDto.getRole()))
+                .build();
+
+        adminRepository.save(admin);
+
+
+    }
+
+    @Override
+    public void updateStatus(Long adminId, Admin.AdminStatus status) {
+
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+        admin.updateStatus(status);
+    }
 }

--- a/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/AdminServiceImpl.java
@@ -67,6 +67,7 @@ public class AdminServiceImpl implements AdminService {
                 .password(encodedPassword) //암호화된 비밀번호 저장
                 .adminPhone(adminCreateRequestDto.getAdminPhone())
                 .role(Admin.AdminRole.valueOf(adminCreateRequestDto.getRole()))
+                .status(Admin.AdminStatus.ACTIVE)
                 .build();
 
         adminRepository.save(admin);

--- a/src/main/java/co/kr/allpick/domain/admin/service/impl/AdminServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/impl/AdminServiceImpl.java
@@ -44,11 +44,12 @@ public class AdminServiceImpl implements AdminService {
         JwtUserInfoDto jwtUserInfoDto = new JwtUserInfoDto(
                 admin.getAdminId(),
                 admin.getEmail(),
-                admin.getRole().name()
+                null
         );
 
         String token = jwtProvider.createToken(jwtUserInfoDto);
 
+        logger.info("[AdminServiceImpl] 관리자 로그인 성공 - adminId: {}", admin.getAdminId());
 
         return AdminLoginResponseDto.from(admin, token);
 
@@ -65,7 +66,7 @@ public class AdminServiceImpl implements AdminService {
 
         adminRepository.save(admin);
 
-
+        logger.info("[AdminServiceImpl] 관리자 등록 완료 - email: {}", adminCreateRequestDto.getEmail());
     }
 
     @Override
@@ -74,5 +75,7 @@ public class AdminServiceImpl implements AdminService {
         Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
         admin.updateStatus(status);
+
+        logger.info("[AdminServiceImpl] 관리자 상태 변경 - adminId: {}, status: {}", adminId, status);
     }
 }

--- a/src/main/java/co/kr/allpick/domain/admin/service/impl/AdminServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/impl/AdminServiceImpl.java
@@ -1,4 +1,4 @@
-package co.kr.allpick.domain.admin.service;
+package co.kr.allpick.domain.admin.service.impl;
 
 
 import co.kr.allpick.domain.admin.dto.AdminCreateRequestDto;
@@ -6,16 +6,18 @@ import co.kr.allpick.domain.admin.dto.AdminLoginRequestDto;
 import co.kr.allpick.domain.admin.dto.AdminLoginResponseDto;
 import co.kr.allpick.domain.admin.entity.Admin;
 import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.domain.admin.service.AdminService;
 import co.kr.allpick.global.config.JwtProvider;
 import co.kr.allpick.global.config.JwtUserInfoDto;
 import co.kr.allpick.global.exception.BusinessException;
 import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-@Slf4j
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 @Service
 @RequiredArgsConstructor
 public class AdminServiceImpl implements AdminService {
@@ -23,6 +25,8 @@ public class AdminServiceImpl implements AdminService {
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private static final Logger logger =
+            LogManager.getLogger(AdminServiceImpl.class);
 
     @Override
     public AdminLoginResponseDto adminLogin(AdminLoginRequestDto adminLoginRequestDto) {
@@ -46,11 +50,7 @@ public class AdminServiceImpl implements AdminService {
         String token = jwtProvider.createToken(jwtUserInfoDto);
 
 
-        return AdminLoginResponseDto.builder()
-                .adminName(admin.getAdminName())
-                .role(admin.getRole().name())
-                .token(token)
-                .build();
+        return AdminLoginResponseDto.from(admin, token);
 
     }
 

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -25,8 +25,13 @@ public enum ErrorCode {
     NOT_SELLER(HttpStatus.FORBIDDEN, "NOT_SELLER", "판매자 권한이 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "회원을 찾을 수 없습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "이메일 또는 비밀번호가 틀렸습니다.");
-	
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "이메일 또는 비밀번호가 틀렸습니다."),
+
+    //Admin
+    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_NOT_FOUND", "관리자를 찾을 수 없습니다."),
+    ADMIN_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "ADMIN_DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.");
+
+
     private final HttpStatus status;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 작업 내용
- adminLogin: 이메일/비밀번호 검증 후 JWT 토큰 발급
- createAdmin: 비밀번호 BCrypt 암호화 후 관리자 등록
- updateStatus: 관리자 상태 변경 (ACTIVE/BLOCKED)

## 변경 파일
- AdminServiceImpl.java

## 참고
- JwtProvider.createToken() 사용하여 토큰 생성
- AdminRole, AdminStatus enum 타입 적용