### PR TITLE
fix: 쿠폰 관련 이슈해결

### DIFF
--- a/src/main/java/co/kr/allpick/domain/coupon/controller/docs/CouponControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/coupon/controller/docs/CouponControllerDocs.java
@@ -22,9 +22,9 @@ public interface CouponControllerDocs {
 
     @Operation(summary = "쿠폰 등록", description = "관리자가 쿠폰을 등록합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "쿠폰 등록 성공",
-            content = @Content(examples = @ExampleObject(value = """
-                { 	 
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "쿠폰 등록 성공",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
                     "success": true,
                     "message": "쿠폰이 등록되었습니다.",
                     "data": {
@@ -38,11 +38,19 @@ public interface CouponControllerDocs {
                     }
                 }
             """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "중복된 쿠폰 코드",
-            content = @Content(examples = @ExampleObject(value = """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 요청",
+                    content = @Content(examples = @ExampleObject(value = """
                 {
                     "success": false,
                     "message": "이미 존재하는 쿠폰 코드입니다.",
+                    "data": null
+                }
+            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 할인값",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": false,
+                    "message": "PERCENT 할인값은 1~100 사이여야 합니다.",
                     "data": null
                 }
             """)))
@@ -52,25 +60,49 @@ public interface CouponControllerDocs {
 
     @Operation(summary = "쿠폰 발급", description = "회원에게 쿠폰을 발급합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "쿠폰 발급 성공",
-            content = @Content(examples = @ExampleObject(value = """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "쿠폰 발급 성공",
+                    content = @Content(examples = @ExampleObject(value = """
                 {
                     "success": true,
                     "message": "쿠폰이 발급되었습니다.",
                     "data": {
                         "memberCouponId": 1,
                         "memberId": 1,
-                        "coupon": {},
+                        "coupon": {
+                            "couponId": 1,
+                            "couponCode": "WELCOME2026",
+                            "discountType": "PERCENT",
+                            "discountValue": 10,
+                            "minOrderAmount": 10000,
+                            "maxDiscount": 5000,
+                            "expiredAt": "2026-12-31T23:59:59"
+                        },
                         "isUsed": false,
                         "usedAt": null
                     }
                 }
             """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "쿠폰을 찾을 수 없습니다.",
-            content = @Content(examples = @ExampleObject(value = """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 보유한 쿠폰",
+                    content = @Content(examples = @ExampleObject(value = """
                 {
                     "success": false,
-                    "message": "쿠폰을 찾을 수 없습니다.",
+                    "message": "이미 보유한 쿠폰입니다.",
+                    "data": null
+                }
+            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "만료된 쿠폰",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": false,
+                    "message": "만료된 쿠폰입니다.",
+                    "data": null
+                }
+            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 또는 쿠폰 없음",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": false,
+                    "message": "회원을 찾을 수 없습니다.",
                     "data": null
                 }
             """)))
@@ -81,12 +113,36 @@ public interface CouponControllerDocs {
 
     @Operation(summary = "회원 보유 쿠폰 목록 조회", description = "회원이 보유한 전체 쿠폰 목록을 조회합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
-            content = @Content(examples = @ExampleObject(value = """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(examples = @ExampleObject(value = """
                 {
                     "success": true,
                     "message": "보유 쿠폰 목록 조회 성공.",
-                    "data": []
+                    "data": [
+                        {
+                            "memberCouponId": 1,
+                            "memberId": 1,
+                            "coupon": {
+                                "couponId": 1,
+                                "couponCode": "WELCOME2026",
+                                "discountType": "PERCENT",
+                                "discountValue": 10,
+                                "minOrderAmount": 10000,
+                                "maxDiscount": 5000,
+                                "expiredAt": "2026-12-31T23:59:59"
+                            },
+                            "isUsed": false,
+                            "usedAt": null
+                        }
+                    ]
+                }
+            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 없음",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": false,
+                    "message": "회원을 찾을 수 없습니다.",
+                    "data": null
                 }
             """)))
     })
@@ -95,30 +151,70 @@ public interface CouponControllerDocs {
 
     @Operation(summary = "회원 미사용 쿠폰 목록 조회", description = "회원이 보유한 미사용 쿠폰 목록을 조회합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
-            content = @Content(examples = @ExampleObject(value = """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(examples = @ExampleObject(value = """
                 {
                     "success": true,
                     "message": "미사용 쿠폰 목록 조회 성공.",
-                    "data": []
+                    "data": [
+                        {
+                            "memberCouponId": 1,
+                            "memberId": 1,
+                            "coupon": {
+                                "couponId": 1,
+                                "couponCode": "WELCOME2026",
+                                "discountType": "PERCENT",
+                                "discountValue": 10,
+                                "minOrderAmount": 10000,
+                                "maxDiscount": 5000,
+                                "expiredAt": "2026-12-31T23:59:59"
+                            },
+                            "isUsed": false,
+                            "usedAt": null
+                        }
+                    ]
+                }
+            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 없음",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": false,
+                    "message": "회원을 찾을 수 없습니다.",
+                    "data": null
                 }
             """)))
     })
     ResponseEntity<ApiResponse<List<MemberCouponResponseDto>>> getUnusedCoupons(
             @PathVariable("memberId") Long memberId);
 
-    @Operation(summary = "쿠폰 코드 조회", description = "쿠폰 코드로 쿠폰 정보를 조회합니다.")
+    @Operation(summary = "쿠폰 코드 조회", description = "쿠폰 코드로 쿠폰 정보를 조회합니다. 만료된 쿠폰은 조회되지 않습니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
-            content = @Content(examples = @ExampleObject(value = """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(examples = @ExampleObject(value = """
                 {
                     "success": true,
                     "message": "쿠폰 조회 성공.",
-                    "data": {}
+                    "data": {
+                        "couponId": 1,
+                        "couponCode": "WELCOME2026",
+                        "discountType": "PERCENT",
+                        "discountValue": 10,
+                        "minOrderAmount": 10000,
+                        "maxDiscount": 5000,
+                        "expiredAt": "2026-12-31T23:59:59"
+                    }
                 }
             """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "쿠폰을 찾을 수 없습니다.",
-            content = @Content(examples = @ExampleObject(value = """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "만료된 쿠폰",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": false,
+                    "message": "만료된 쿠폰입니다.",
+                    "data": null
+                }
+            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "쿠폰 없음",
+                    content = @Content(examples = @ExampleObject(value = """
                 {
                     "success": false,
                     "message": "쿠폰을 찾을 수 없습니다.",

--- a/src/main/java/co/kr/allpick/domain/coupon/dto/CouponRegisterRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/coupon/dto/CouponRegisterRequestDto.java
@@ -1,8 +1,7 @@
 package co.kr.allpick.domain.coupon.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,17 +27,21 @@ public class CouponRegisterRequestDto {
     private DiscountType discountType;
 
     @NotNull
-    @Schema(description = "할인값", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+    @DecimalMin(value = "0.01", message = "할인값은 0보다 커야 합니다.")
+    @Schema(description = "할인값 (PERCENT: 1~100, AMOUNT: 양수)", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
     private BigDecimal discountValue;
 
     @NotNull
+    @DecimalMin(value = "0.01", message = "최소 주문금액은 0보다 커야 합니다.")
     @Schema(description = "최소 주문금액", example = "10000", requiredMode = Schema.RequiredMode.REQUIRED)
     private BigDecimal minOrderAmount;
 
+    @DecimalMin(value = "0.01", message = "최대 할인금액은 0보다 커야 합니다.")
     @Schema(description = "최대 할인금액", example = "5000")
     private BigDecimal maxDiscount;
 
     @NotNull
+    @Future(message = "만료일은 현재 시간 이후여야 합니다.")
     @Schema(description = "만료일", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime expiredAt;
 

--- a/src/main/java/co/kr/allpick/domain/coupon/service/impl/CouponServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/coupon/service/impl/CouponServiceImpl.java
@@ -8,6 +8,7 @@ import co.kr.allpick.domain.coupon.entity.MemberCoupon;
 import co.kr.allpick.domain.coupon.repository.CouponRepository;
 import co.kr.allpick.domain.coupon.repository.MemberCouponRepository;
 import co.kr.allpick.domain.coupon.service.CouponService;
+import co.kr.allpick.domain.member.repository.MemberRepository;
 import co.kr.allpick.global.exception.BusinessException;
 import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,8 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,11 +30,18 @@ public class CouponServiceImpl implements CouponService {
 
     private final CouponRepository couponRepository;
     private final MemberCouponRepository memberCouponRepository;
+    private final MemberRepository memberRepository; // #18, #22 회원 존재 검증용
 
     @Override
     @Transactional
     public CouponResponseDto registerCoupon(CouponRegisterRequestDto request) {
         logger.info("쿠폰 등록 요청 - couponCode: {}", request.getCouponCode());
+
+        // #16 PERCENT 타입 100% 초과 검증
+        if (request.getDiscountType() == Coupon.DiscountType.PERCENT
+                && request.getDiscountValue().compareTo(BigDecimal.valueOf(100)) > 0) {
+            throw new BusinessException(ErrorCode.INVALID_DISCOUNT_VALUE);
+        }
 
         if (couponRepository.existsByCouponCode(request.getCouponCode())) {
             throw new BusinessException(ErrorCode.COUPON_CODE_DUPLICATE);
@@ -47,10 +57,19 @@ public class CouponServiceImpl implements CouponService {
     public MemberCouponResponseDto issueCoupon(Long memberId, Long couponId) {
         logger.info("쿠폰 발급 요청 - memberId: {}, couponId: {}", memberId, couponId);
 
+        // #18 회원 존재 검증
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
 
-        // 중복 발급 체크
+        // #23 만료된 쿠폰 발급 방지
+        if (coupon.getExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.COUPON_EXPIRED);
+        }
+
+        // #17 중복 발급 체크
         if (memberCouponRepository.existsByMemberIdAndCoupon_CouponId(memberId, couponId)) {
             throw new BusinessException(ErrorCode.COUPON_ALREADY_ISSUED);
         }
@@ -69,6 +88,11 @@ public class CouponServiceImpl implements CouponService {
     @Transactional(readOnly = true)
     public List<MemberCouponResponseDto> getMemberCoupons(Long memberId) {
         logger.info("회원 쿠폰 목록 조회 - memberId: {}", memberId);
+
+        // #22 회원 존재 검증
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
         return memberCouponRepository.findByMemberId(memberId)
                 .stream()
                 .map(MemberCouponResponseDto::from)
@@ -79,6 +103,11 @@ public class CouponServiceImpl implements CouponService {
     @Transactional(readOnly = true)
     public List<MemberCouponResponseDto> getUnusedCoupons(Long memberId) {
         logger.info("회원 미사용 쿠폰 조회 - memberId: {}", memberId);
+
+        // #22 회원 존재 검증
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
         return memberCouponRepository.findByMemberIdAndIsUsed(memberId, false)
                 .stream()
                 .map(MemberCouponResponseDto::from)
@@ -91,6 +120,11 @@ public class CouponServiceImpl implements CouponService {
         logger.info("쿠폰 코드 조회 - couponCode: {}", couponCode);
         Coupon coupon = couponRepository.findByCouponCode(couponCode)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (coupon.getExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.COUPON_EXPIRED);
+        }
+
         return CouponResponseDto.from(coupon);
     }
 }

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "COUPON_NOT_FOUND", "쿠폰을 찾을 수 없습니다."),
     COUPON_CODE_DUPLICATE(HttpStatus.BAD_REQUEST, "COUPON_CODE_DUPLICATE", "이미 존재하는 쿠폰 코드입니다."),
     COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_USED", "이미 사용된 쿠폰입니다."),
+    INVALID_DISCOUNT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_DISCOUNT_VALUE", "PERCENT 할인값은 1~100 사이여야 합니다."),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "COUPON_EXPIRED", "만료된 쿠폰입니다."),
 
     // Inquiry

--- a/src/test/java/co/kr/allpick/domain/coupon/service/impl/CouponServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/coupon/service/impl/CouponServiceImplTest.java
@@ -7,7 +7,8 @@ import co.kr.allpick.domain.coupon.entity.Coupon;
 import co.kr.allpick.domain.coupon.entity.MemberCoupon;
 import co.kr.allpick.domain.coupon.repository.CouponRepository;
 import co.kr.allpick.domain.coupon.repository.MemberCouponRepository;
-import co.kr.allpick.domain.coupon.service.impl.CouponServiceImpl;
+import co.kr.allpick.domain.member.entity.Member;
+import co.kr.allpick.domain.member.repository.MemberRepository;
 import co.kr.allpick.global.exception.BusinessException;
 import co.kr.allpick.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -25,19 +26,17 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CouponServiceImplTest {
 
-    @Mock
-    CouponRepository couponRepository;
+    @Mock CouponRepository couponRepository;
+    @Mock MemberCouponRepository memberCouponRepository;
+    @Mock MemberRepository memberRepository;
 
-    @Mock
-    MemberCouponRepository memberCouponRepository;
-
-    @InjectMocks
-    CouponServiceImpl couponService;
+    @InjectMocks CouponServiceImpl couponService;
 
     @Test
     @DisplayName("쿠폰 등록 성공")
@@ -107,7 +106,9 @@ class CouponServiceImplTest {
                 .coupon(mockCoupon)
                 .build();
 
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mock(Member.class)));
         when(couponRepository.findById(couponId)).thenReturn(Optional.of(mockCoupon));
+        when(memberCouponRepository.existsByMemberIdAndCoupon_CouponId(memberId, couponId)).thenReturn(false);
         when(memberCouponRepository.save(any(MemberCoupon.class))).thenReturn(mockMemberCoupon);
 
         // when
@@ -123,6 +124,7 @@ class CouponServiceImplTest {
     @DisplayName("쿠폰 발급 실패 - 쿠폰 없음")
     void 쿠폰_발급_실패_쿠폰없음() {
         // given
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(mock(Member.class)));
         when(couponRepository.findById(999L)).thenReturn(Optional.empty());
 
         // when & then
@@ -131,35 +133,6 @@ class CouponServiceImplTest {
                 .hasMessage(ErrorCode.COUPON_NOT_FOUND.getMessage());
     }
 
-    @Test
-    @DisplayName("회원 미사용 쿠폰 목록 조회 성공")
-    void 회원_미사용_쿠폰_목록_조회_성공() {
-        // given
-        Long memberId = 1L;
-        Coupon mockCoupon = Coupon.builder()
-                .couponCode("WELCOME2026")
-                .discountType(Coupon.DiscountType.PERCENT)
-                .discountValue(BigDecimal.valueOf(10))
-                .minOrderAmount(BigDecimal.valueOf(10000))
-                .maxDiscount(BigDecimal.valueOf(5000))
-                .expiredAt(LocalDateTime.now().plusMonths(1))
-                .build();
-
-        MemberCoupon mockMemberCoupon = MemberCoupon.builder()
-                .memberId(memberId)
-                .coupon(mockCoupon)
-                .build();
-
-        when(memberCouponRepository.findByMemberIdAndIsUsed(memberId, false))
-                .thenReturn(List.of(mockMemberCoupon));
-
-        // when
-        List<MemberCouponResponseDto> result = couponService.getUnusedCoupons(memberId);
-
-        // then
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).isUsed()).isFalse();
-    }
     @Test
     @DisplayName("쿠폰 발급 실패 - 이미 보유한 쿠폰")
     void 쿠폰_발급_실패_이미보유() {
@@ -176,6 +149,7 @@ class CouponServiceImplTest {
                 .expiredAt(LocalDateTime.now().plusMonths(1))
                 .build();
 
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mock(Member.class)));
         when(couponRepository.findById(couponId)).thenReturn(Optional.of(mockCoupon));
         when(memberCouponRepository.existsByMemberIdAndCoupon_CouponId(memberId, couponId)).thenReturn(true);
 
@@ -183,5 +157,37 @@ class CouponServiceImplTest {
         assertThatThrownBy(() -> couponService.issueCoupon(memberId, couponId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.COUPON_ALREADY_ISSUED.getMessage());
+    }
+
+    @Test
+    @DisplayName("회원 미사용 쿠폰 목록 조회 성공")
+    void 회원_미사용_쿠폰_목록_조회_성공() {
+        // given
+        Long memberId = 1L;
+
+        Coupon mockCoupon = Coupon.builder()
+                .couponCode("WELCOME2026")
+                .discountType(Coupon.DiscountType.PERCENT)
+                .discountValue(BigDecimal.valueOf(10))
+                .minOrderAmount(BigDecimal.valueOf(10000))
+                .maxDiscount(BigDecimal.valueOf(5000))
+                .expiredAt(LocalDateTime.now().plusMonths(1))
+                .build();
+
+        MemberCoupon mockMemberCoupon = MemberCoupon.builder()
+                .memberId(memberId)
+                .coupon(mockCoupon)
+                .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mock(Member.class)));
+        when(memberCouponRepository.findByMemberIdAndIsUsed(memberId, false))
+                .thenReturn(List.of(mockMemberCoupon));
+
+        // when
+        List<MemberCouponResponseDto> result = couponService.getUnusedCoupons(memberId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).isUsed()).isFalse();
     }
 }

--- a/src/test/java/co/kr/allpick/domain/member/membership/service/impl/MembershipServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/member/membership/service/impl/MembershipServiceImplTest.java
@@ -23,6 +23,8 @@ import co.kr.allpick.domain.member.membership.entity.MembershipHistory;
 import co.kr.allpick.domain.member.membership.repository.MembershipHistoryRepository;
 import co.kr.allpick.domain.member.repository.MemberRepository;
 import co.kr.allpick.domain.order.repository.OrderRepository;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class MembershipServiceImplTest {
@@ -40,7 +42,8 @@ class MembershipServiceImplTest {
         Member member = mock(Member.class);
         when(member.getId()).thenReturn(1L);
         when(member.getGrade()).thenReturn(MemberGrade.NORMAL);
-        when(memberRepository.findAll()).thenReturn(List.of(member));
+        when(memberRepository.findAll(any(PageRequest.class)))
+        .thenReturn(new PageImpl<>(List.of(member)));
 
         List<Object[]> mockResult = new ArrayList<>();
         mockResult.add(new Object[]{1L, new BigDecimal("350000")});
@@ -63,7 +66,8 @@ class MembershipServiceImplTest {
         Member member = mock(Member.class);
         when(member.getId()).thenReturn(1L);
         when(member.getGrade()).thenReturn(MemberGrade.NORMAL);
-        when(memberRepository.findAll()).thenReturn(List.of(member));
+        when(memberRepository.findAll(any(PageRequest.class)))
+        .thenReturn(new PageImpl<>(List.of(member)));
 
         List<Object[]> mockResult = new ArrayList<>();
         when(orderRepository.sumDeliveredAmountByMemberBetween(any(), any()))
@@ -84,7 +88,8 @@ class MembershipServiceImplTest {
         Member member = mock(Member.class);
         when(member.getId()).thenReturn(2L);
         when(member.getGrade()).thenReturn(MemberGrade.GOLD);
-        when(memberRepository.findAll()).thenReturn(List.of(member));
+        when(memberRepository.findAll(any(PageRequest.class)))
+        .thenReturn(new PageImpl<>(List.of(member)));
 
         List<Object[]> mockResult = new ArrayList<>();
         mockResult.add(new Object[]{2L, new BigDecimal("3500000")});


### PR DESCRIPTION
## 개요
쿠폰 도메인 관련 이슈 해결

---

## 작업 내용
- [ ] 버그 수정
- [ ] 문서 수정

### 주요 변경 사항
- Controller: CouponControllerDocs Swagger 응답 명세 추가
- Service: CouponServiceImpl 유효성 검증 로직 추가
- Repository: 변경 없음
- 기타: CouponRegisterRequestDto 유효성 검증 추가, CouponServiceImplTest 수정

---

## 관련 이슈
- close #16 
- close #17 
- close #18 
- close #19 
- close #20 
- close #21 
- close #22 
- close #23 

---

## 변경 전 / 후
### Before
- 음수, 100% 초과 할인값 저장 가능
- 만료된 쿠폰 발급/조회 가능
- 존재하지 않는 회원에게 쿠폰 발급 가능
- Swagger 응답 명세 불일치

### After
- 유효성 검증으로 음수/초과값 차단
- 만료된 쿠폰 발급/조회 차단
- 존재하지 않는 회원 검증 추가
- Swagger 응답 명세 실제 응답과 일치


