### PR TITLE
fix: delivery 이슈 해결

### DIFF
--- a/src/main/java/co/kr/allpick/domain/order/repository/DeliveryAddressRepository.java
+++ b/src/main/java/co/kr/allpick/domain/order/repository/DeliveryAddressRepository.java
@@ -10,4 +10,5 @@ import co.kr.allpick.domain.order.entity.DeliveryAddress;
 @Component("deliveryAddressRepositoryHandler")
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress, Long> {
     List<DeliveryAddress> findByMemberId(Long memberId);
+    boolean existsByMemberIdAndAddressAndAddressDetail(Long memberId, String address, String addressDetail);
 }

--- a/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
@@ -6,6 +6,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import co.kr.allpick.domain.member.repository.MemberRepository;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderItemRepository orderItemRepository;
     private final PaymentRepository paymentRepository;
     private final DeliveryAddressRepository deliveryAddressRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
@@ -92,6 +94,17 @@ public class OrderServiceImpl implements OrderService {
     @Transactional
     public DeliveryAddressResponseDto addDeliveryAddress(Long memberId, DeliveryAddressRequestDto request) {
         logger.info("배송지 추가 - memberId: {}", memberId);
+
+        // #26 회원 존재 검증
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // #26 중복 배송지 검증
+        if (deliveryAddressRepository.existsByMemberIdAndAddressAndAddressDetail(
+                memberId, request.getAddress(), request.getAddressDetail())) {
+            throw new BusinessException(ErrorCode.DELIVERY_ADDRESS_DUPLICATE);
+        }
+
         DeliveryAddressResponseDto saved = DeliveryAddressResponseDto.from(
                 deliveryAddressRepository.save(request.toEntity(memberId)));
         logger.info("배송지 추가 완료 - addressId: {}", saved.getAddressId());

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_ITEM_NOT_FOUND", "주문 상품을 찾을 수 없습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "결제 정보를 찾을 수 없습니다."),
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS_NOT_FOUND", "배송지를 찾을 수 없습니다."),
+    DELIVERY_ADDRESS_DUPLICATE(HttpStatus.CONFLICT, "DELIVERY_ADDRESS_DUPLICATE", "이미 등록된 배송지입니다."),
 
     // Coupon
     COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "COUPON_ALREADY_ISSUED", "이미 보유한 쿠폰입니다."),


### PR DESCRIPTION
## 개요
- delivery 관련해서 이슈 해결
---

## 작업 내용
- [ ] 버그 수정

### 주요 변경 사항
- Service: 중복 배송지 검증하는 로직 생성
- Repository: 중복 체크하는 메서드 생성

---

## 관련 이슈
- close #26 

---

## 변경 전 / 후
### Before
- 기존엔 배송지 추가 시 동일한 회원이 여러 번 값은 값으로 추가가 가능했으며, 존재하지 않는 회원에 대해 배송지 추가가 정삭적으로 동작하였음.

### After
- 존재하지 않는 회원 memberRepository.findById()로 검증 추가
- 중복 배송지 existsByMemberIdAndAddressAndAddressDetail()로 검증 추가