### PR TITLE
feat: 회원 정보 조회 API 추가

### DIFF
--- a/src/main/java/co/kr/allpick/domain/member/controller/MemberController.java
+++ b/src/main/java/co/kr/allpick/domain/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package co.kr.allpick.domain.member.controller;
+
+import co.kr.allpick.domain.member.docs.MemberControllerDocs;
+import co.kr.allpick.domain.member.dto.MemberResponseDto;
+import co.kr.allpick.domain.member.service.MemberService;
+import co.kr.allpick.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController implements MemberControllerDocs {
+
+    private final MemberService memberService;
+
+    @Override
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ApiResponse<MemberResponseDto>> getMember(
+            @PathVariable Long memberId) {
+        return ApiResponse.success("회원 정보 조회 성공", memberService.getMember(memberId));
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/member/docs/MemberControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/member/docs/MemberControllerDocs.java
@@ -1,0 +1,44 @@
+package co.kr.allpick.domain.member.docs;
+
+import co.kr.allpick.domain.member.dto.MemberResponseDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Member", description = "회원 API")
+public interface MemberControllerDocs {
+
+    @Operation(summary = "회원 정보 조회", description = "회원 ID로 회원 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": true,
+                    "message": "회원 정보 조회 성공",
+                    "data": {
+                        "id": 1,
+                        "email": "test@test.com",
+                        "name": "김상우",
+                        "phone": "01012345678",
+                        "address": "인천광역시 미추홀구",
+                        "grade": "NORMAL"
+                    }
+                }
+            """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 없음",
+                    content = @Content(examples = @ExampleObject(value = """
+                {
+                    "success": false,
+                    "message": "회원을 찾을 수 없습니다.",
+                    "data": null
+                }
+            """)))
+    })
+        // 수정
+    ResponseEntity<ApiResponse<MemberResponseDto>> getMember(@PathVariable Long memberId);
+}

--- a/src/main/java/co/kr/allpick/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/member/dto/MemberResponseDto.java
@@ -1,0 +1,44 @@
+package co.kr.allpick.domain.member.dto;
+
+import co.kr.allpick.domain.member.entity.Member;
+import co.kr.allpick.domain.member.entity.MemberGrade;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회원 정보 응답 DTO")
+public class MemberResponseDto {
+
+    @Schema(description = "회원 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "이메일", example = "test@test.com")
+    private String email;
+
+    @Schema(description = "이름", example = "김상우")
+    private String name;
+
+    @Schema(description = "전화번호", example = "01012345678")
+    private String phone;
+
+    @Schema(description = "주소", example = "인천광역시 미추홀구")
+    private String address;
+
+    @Schema(description = "멤버십 등급", example = "NORMAL")
+    private MemberGrade grade;
+
+    public static MemberResponseDto from(Member member) {
+        return new MemberResponseDto(
+                member.getId(),
+                member.getEmail(),
+                member.getName(),
+                member.getPhone(),
+                member.getAddress(),
+                member.getGrade()
+        );
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/member/service/MemberService.java
+++ b/src/main/java/co/kr/allpick/domain/member/service/MemberService.java
@@ -1,0 +1,7 @@
+package co.kr.allpick.domain.member.service;
+
+import co.kr.allpick.domain.member.dto.MemberResponseDto;
+
+public interface MemberService {
+    MemberResponseDto getMember(Long memberId);
+}

--- a/src/main/java/co/kr/allpick/domain/member/service/impl/AuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/member/service/impl/AuthServiceImpl.java
@@ -1,5 +1,6 @@
-package co.kr.allpick.domain.member.service;
+package co.kr.allpick.domain.member.service.impl;
 
+import co.kr.allpick.domain.member.service.AuthService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/co/kr/allpick/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/member/service/impl/MemberServiceImpl.java
@@ -1,0 +1,30 @@
+package co.kr.allpick.domain.member.service.impl;
+
+import co.kr.allpick.domain.member.dto.MemberResponseDto;
+import co.kr.allpick.domain.member.repository.MemberRepository;
+import co.kr.allpick.domain.member.service.MemberService;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private static final Logger logger = LogManager.getLogger(MemberServiceImpl.class);
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberResponseDto getMember(Long memberId) {
+        logger.info("회원 정보 조회 - memberId: {}", memberId);
+        return memberRepository.findById(memberId)
+                .map(MemberResponseDto::from)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/test/java/co/kr/allpick/domain/member/service/Impl/AuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/member/service/Impl/AuthServiceImplTest.java
@@ -1,0 +1,151 @@
+package co.kr.allpick.domain.member.service.Impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import co.kr.allpick.domain.member.dto.AuthResponseDto;
+import co.kr.allpick.domain.member.dto.LoginRequestDto;
+import co.kr.allpick.domain.member.dto.SignupRequestDto;
+import co.kr.allpick.domain.member.entity.Member;
+import co.kr.allpick.domain.member.repository.MemberRepository;
+import co.kr.allpick.domain.member.service.impl.AuthServiceImpl;
+import co.kr.allpick.global.config.JwtProvider;
+import co.kr.allpick.global.config.JwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import co.kr.allpick.domain.seller.repository.SellerRepository;
+
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    SellerRepository sellerRepository;
+    
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    JwtProvider jwtProvider;
+
+    @InjectMocks
+    AuthServiceImpl authService;
+
+    // ==================== 일반 회원가입 ====================
+
+    @Test
+    @DisplayName("일반 회원가입 성공")
+    void 일반_회원가입_성공() {
+        // given
+        SignupRequestDto dto = new SignupRequestDto(
+            "test@test.com", "password123", "홍길동", "010-1234-5678", "서울시 강남구", true, true, false);
+
+        when(memberRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+        when(passwordEncoder.encode(dto.getPassword())).thenReturn("encodedPassword");
+
+        // when
+        authService.signup(dto);
+
+        // then
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("일반 회원가입 실패 - 중복 이메일")
+    void 일반_회원가입_실패_중복이메일() {
+        // given
+        SignupRequestDto dto = new SignupRequestDto(
+            "test@test.com", "password123", "홍길동", "010-1234-5678", "서울시 강남구", true, true, false);
+
+        when(memberRepository.existsByEmail(dto.getEmail())).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> authService.signup(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
+    }
+    // ==================== 로그인 ====================
+
+    @Test
+    @DisplayName("로그인 성공")
+    void 로그인_성공() {
+        // given
+        LoginRequestDto dto = new LoginRequestDto("test@test.com", "password123");
+
+        Member mockMember = Member.builder()
+                .email("test@test.com")
+                .password("encodedPassword")
+                .name("홍길동")
+                .phone("010-1234-5678")
+                .address("서울시 강남구")
+                .build();
+
+        when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(mockMember));
+        when(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).thenReturn(true);
+        when(jwtProvider.createToken(any(JwtUserInfoDto.class))).thenReturn("mockToken");
+
+        // when
+        AuthResponseDto result = authService.login(dto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getToken()).isEqualTo("mockToken");
+        assertThat(result.getEmail()).isEqualTo("test@test.com");
+        assertThat(result.getName()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 이메일 없음")
+    void 로그인_실패_이메일없음() {
+        // given
+        LoginRequestDto dto = new LoginRequestDto("none@test.com", "password123");
+
+        when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 틀림")
+    void 로그인_실패_비밀번호틀림() {
+        // given
+        LoginRequestDto dto = new LoginRequestDto("test@test.com", "wrongPassword");
+
+        Member mockMember = Member.builder()
+                .email("test@test.com")
+                .password("encodedPassword")
+                .name("홍길동")
+                .phone("010-1234-5678")
+                .address("서울시 강남구")
+                .build();
+
+
+        when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(mockMember));
+        when(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+    }
+}

--- a/src/test/java/co/kr/allpick/domain/member/service/Impl/MemberServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/member/service/Impl/MemberServiceImplTest.java
@@ -1,34 +1,24 @@
 package co.kr.allpick.domain.member.service.Impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Optional;
-
+import co.kr.allpick.domain.member.dto.MemberResponseDto;
+import co.kr.allpick.domain.member.entity.Member;
+import co.kr.allpick.domain.member.entity.MemberGrade;
+import co.kr.allpick.domain.member.repository.MemberRepository;
+import co.kr.allpick.domain.member.service.impl.MemberServiceImpl;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
-import co.kr.allpick.domain.member.dto.AuthResponseDto;
-import co.kr.allpick.domain.member.dto.LoginRequestDto;
-import co.kr.allpick.domain.member.dto.SignupRequestDto;
-import co.kr.allpick.domain.member.entity.Member;
-import co.kr.allpick.domain.member.repository.MemberRepository;
-import co.kr.allpick.domain.member.service.AuthServiceImpl;
-import co.kr.allpick.global.config.JwtProvider;
-import co.kr.allpick.global.config.JwtUserInfoDto;
-import co.kr.allpick.global.exception.BusinessException;
-import co.kr.allpick.global.exception.ErrorCode;
-import co.kr.allpick.domain.seller.repository.SellerRepository;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceImplTest {
@@ -36,116 +26,43 @@ class MemberServiceImplTest {
     @Mock
     MemberRepository memberRepository;
 
-    @Mock
-    SellerRepository sellerRepository;
-    
-    @Mock
-    PasswordEncoder passwordEncoder;
-
-    @Mock
-    JwtProvider jwtProvider;
-
     @InjectMocks
-    AuthServiceImpl authService;
-
-    // ==================== 일반 회원가입 ====================
+    MemberServiceImpl memberService;
 
     @Test
-    @DisplayName("일반 회원가입 성공")
-    void 일반_회원가입_성공() {
+    @DisplayName("회원 정보 조회 성공")
+    void 회원_정보_조회_성공() {
         // given
-        SignupRequestDto dto = new SignupRequestDto(
-            "test@test.com", "password123", "홍길동", "010-1234-5678", "서울시 강남구", true, true, false);
-
-        when(memberRepository.existsByEmail(dto.getEmail())).thenReturn(false);
-        when(passwordEncoder.encode(dto.getPassword())).thenReturn("encodedPassword");
-
-        // when
-        authService.signup(dto);
-
-        // then
-        verify(memberRepository, times(1)).save(any(Member.class));
-    }
-
-    @Test
-    @DisplayName("일반 회원가입 실패 - 중복 이메일")
-    void 일반_회원가입_실패_중복이메일() {
-        // given
-        SignupRequestDto dto = new SignupRequestDto(
-            "test@test.com", "password123", "홍길동", "010-1234-5678", "서울시 강남구", true, true, false);
-
-        when(memberRepository.existsByEmail(dto.getEmail())).thenReturn(true);
-
-        // when & then
-        assertThatThrownBy(() -> authService.signup(dto))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.DUPLICATE_EMAIL.getMessage());
-    }
-    // ==================== 로그인 ====================
-
-    @Test
-    @DisplayName("로그인 성공")
-    void 로그인_성공() {
-        // given
-        LoginRequestDto dto = new LoginRequestDto("test@test.com", "password123");
-
+        Long memberId = 1L;
         Member mockMember = Member.builder()
                 .email("test@test.com")
-                .password("encodedPassword")
-                .name("홍길동")
-                .phone("010-1234-5678")
-                .address("서울시 강남구")
+                .name("김상우")
+                .phone("01012345678")
+                .address("인천광역시 미추홀구")
+                .grade(MemberGrade.NORMAL)
                 .build();
 
-        when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(mockMember));
-        when(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).thenReturn(true);
-        when(jwtProvider.createToken(any(JwtUserInfoDto.class))).thenReturn("mockToken");
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
 
         // when
-        AuthResponseDto result = authService.login(dto);
+        MemberResponseDto result = memberService.getMember(memberId);
 
         // then
         assertThat(result).isNotNull();
-        assertThat(result.getToken()).isEqualTo("mockToken");
         assertThat(result.getEmail()).isEqualTo("test@test.com");
-        assertThat(result.getName()).isEqualTo("홍길동");
+        assertThat(result.getName()).isEqualTo("김상우");
+        assertThat(result.getGrade()).isEqualTo(MemberGrade.NORMAL);
     }
 
     @Test
-    @DisplayName("로그인 실패 - 이메일 없음")
-    void 로그인_실패_이메일없음() {
+    @DisplayName("회원 정보 조회 실패 - 존재하지 않는 회원")
+    void 회원_정보_조회_실패_존재하지않는회원() {
         // given
-        LoginRequestDto dto = new LoginRequestDto("none@test.com", "password123");
-
-        when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.empty());
+        when(memberRepository.findById(999L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> authService.login(dto))
+        assertThatThrownBy(() -> memberService.getMember(999L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
-    }
-
-    @Test
-    @DisplayName("로그인 실패 - 비밀번호 틀림")
-    void 로그인_실패_비밀번호틀림() {
-        // given
-        LoginRequestDto dto = new LoginRequestDto("test@test.com", "wrongPassword");
-
-        Member mockMember = Member.builder()
-                .email("test@test.com")
-                .password("encodedPassword")
-                .name("홍길동")
-                .phone("010-1234-5678")
-                .address("서울시 강남구")
-                .build();
-
-
-        when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(mockMember));
-        when(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).thenReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> authService.login(dto))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## 개요
- 멤버십 조회를 위해 멤버 조회 API 작업 + 기존 멤버 테스트 코드 파일명 오류 (Auth로 작업했는데 test에는 member로 돼있음) + service와 impl 분리안된 부분 수정
---

## 작업 내용
- [v] 기능 추가
- [v] 테스트 코드 작성
- [v] 문서 수정

---
## 변경 전 / 후
### Before
- 멤버 조회 API가 없어서 멤버십 등급 조회가 안됐음.
### After
- 멤버십 탭에서 현재 등급 보여주기
- 
<img width="1126" height="824" alt="image" src="https://github.com/user-attachments/assets/86fbe308-969f-4104-8685-94205bb796f6" />
