### PR TITLE
fix: memberid 대신 jwt 패싱된 토큰 받아서 사용

### DIFF
--- a/src/main/java/co/kr/allpick/domain/member/controller/MemberController.java
+++ b/src/main/java/co/kr/allpick/domain/member/controller/MemberController.java
@@ -4,10 +4,11 @@ import co.kr.allpick.domain.member.docs.MemberControllerDocs;
 import co.kr.allpick.domain.member.dto.MemberResponseDto;
 import co.kr.allpick.domain.member.service.MemberService;
 import co.kr.allpick.global.response.ApiResponse;
+import co.kr.allpick.global.config.JwtUserInfoDto; // JwtUserInfoDto 임포트 필요
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal; // 추가
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,11 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberControllerDocs {
 
     private final MemberService memberService;
-
     @Override
-    @GetMapping("/{memberId}")
+    @GetMapping("/me")
     public ResponseEntity<ApiResponse<MemberResponseDto>> getMember(
-            @PathVariable Long memberId) {
-        return ApiResponse.success("회원 정보 조회 성공", memberService.getMember(memberId));
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+
+        return ApiResponse.success("회원 정보 조회 성공", memberService.getMember(userInfo.getMemberId()));
     }
 }

--- a/src/main/java/co/kr/allpick/domain/member/docs/MemberControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/member/docs/MemberControllerDocs.java
@@ -1,6 +1,7 @@
 package co.kr.allpick.domain.member.docs;
 
 import co.kr.allpick.domain.member.dto.MemberResponseDto;
+import co.kr.allpick.global.config.JwtUserInfoDto;
 import co.kr.allpick.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -40,5 +41,5 @@ public interface MemberControllerDocs {
             """)))
     })
         // 수정
-    ResponseEntity<ApiResponse<MemberResponseDto>> getMember(@PathVariable Long memberId);
+    ResponseEntity<ApiResponse<MemberResponseDto>> getMember(JwtUserInfoDto userInfo);
 }


### PR DESCRIPTION
## 개요
- 기존 memberId로 받던 컨트롤러 부분을 jwt를 사용하여 정보를 가져오게 함.
---

## 작업 내용
- [v] 리팩토링


### 주요 변경 사항
- Controller:  @AuthenticationPrincipal JwtUserInfoDto userInfo로 jwt userinfo쪽에 저장된 토큰 사용
---