### PR TITLE
feat: FAQ 도메인 토대 구현 (Entity, Repository, DTO, Service)

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/board/dto/FaqCreateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/dto/FaqCreateRequestDto.java
@@ -1,0 +1,38 @@
+package co.kr.allpick.domain.admin.board.dto;
+
+import co.kr.allpick.domain.admin.board.entity.Faq;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "FAQ 등록 요청 DTO")
+public class FaqCreateRequestDto {
+
+    @NotNull
+    @Schema(description = "FAQ 카테고리", example = "DELIVERY", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Faq.FaqCategory category;
+
+    @NotBlank
+    @Size(max = 200)
+    @Schema(description = "질문", example = "배송은 얼마나 걸리나요?", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String title;
+
+    @NotBlank
+    @Schema(description = "답변", example = "평균 2~3일 소요됩니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String content;
+
+    @NotNull
+    @Schema(description = "노출 순서", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private int displayOrder;
+
+    public Faq toEntity(Long adminId) {
+        return new Faq(adminId, this.category, this.title, this.content, this.displayOrder);
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/dto/FaqResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/dto/FaqResponseDto.java
@@ -1,0 +1,55 @@
+package co.kr.allpick.domain.admin.board.dto;
+
+import co.kr.allpick.domain.admin.board.entity.Faq;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "FAQ 응답 DTO")
+public class FaqResponseDto {
+
+    @Schema(description = "FAQ ID", example = "1")
+    private Long faqId;
+
+    @Schema(description = "관리자 ID", example = "1")
+    private Long adminId;
+
+    @Schema(description = "카테고리 (DELIVERY=배송, PAYMENT=결제, CANCEL_REFUND=취소/환불, MEMBER=회원)", example = "DELIVERY")
+    private Faq.FaqCategory category;
+
+    @Schema(description = "질문", example = "배송은 얼마나 걸리나요?")
+    private String title;
+
+    @Schema(description = "답변", example = "평균 2~3일 소요됩니다.")
+    private String content;
+
+    @Schema(description = "노출 순서", example = "1")
+    private int displayOrder;
+
+    @Schema(description = "노출 여부", example = "true")
+    private boolean isVisible;
+
+    @Schema(description = "등록일시", example = "2026-04-27T00:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2026-04-27T00:00:00")
+    private LocalDateTime updatedAt;
+
+    public static FaqResponseDto from(Faq faq) {
+        return FaqResponseDto.builder()
+                .faqId(faq.getFaqId())
+                .adminId(faq.getAdminId())
+                .category(faq.getCategory())
+                .title(faq.getTitle())
+                .content(faq.getContent())
+                .displayOrder(faq.getDisplayOrder())
+                .isVisible(faq.isVisible())
+                .createdAt(faq.getCreatedAt())
+                .updatedAt(faq.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/entity/Faq.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/entity/Faq.java
@@ -1,0 +1,67 @@
+package co.kr.allpick.domain.admin.board.entity;
+
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "faqs")
+@Getter
+@NoArgsConstructor
+public class Faq extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "faq_id")
+    private Long faqId;
+
+    @Column(name = "admin_id", nullable = false)
+    private Long adminId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private FaqCategory category;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @Column(name = "is_visible", nullable = false)
+    private boolean isVisible;
+
+
+    @Builder
+    public Faq(Long adminId, FaqCategory category, String title,
+               String content, int displayOrder) {
+        this.adminId = adminId;
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.displayOrder = displayOrder;
+        this.isVisible = true;
+    }
+
+    public void update(FaqCategory category, String title,
+                       String content, int displayOrder) {
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.displayOrder = displayOrder;
+    }
+
+    public void toggleVisibility(boolean isVisible) {
+        this.isVisible = isVisible;
+    }
+
+    public enum  FaqCategory {
+        DELIVERY, PAYMENT, CANCEL_REFUND, MEMBER
+    }
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/repository/FaqRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/repository/FaqRepository.java
@@ -1,0 +1,16 @@
+package co.kr.allpick.domain.admin.board.repository;
+
+import co.kr.allpick.domain.admin.board.entity.Faq;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FaqRepository extends JpaRepository<Faq, Long> {
+
+    // 전체 조회 (삭제(deletedAt이 null인 것) 안 된 것만, 순서대로)
+    List<Faq> findAllByDeletedAtIsNullOrderByDisplayOrderAsc();
+
+    // 카테고리 필터 조회 (UI의 배송/결제 탭 클릭시)
+    List<Faq> findAllByCategoryAndDeletedAtIsNullOrderByDisplayOrderAsc(Faq.FaqCategory category);
+
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/service/FaqService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/service/FaqService.java
@@ -1,0 +1,28 @@
+package co.kr.allpick.domain.admin.board.service;
+
+import co.kr.allpick.domain.admin.board.dto.FaqCreateRequestDto;
+import co.kr.allpick.domain.admin.board.dto.FaqResponseDto;
+import co.kr.allpick.domain.admin.board.entity.Faq;
+
+import java.util.List;
+
+public interface FaqService {
+
+    // FAQ 등록
+    FaqResponseDto createFaq(Long adminId, FaqCreateRequestDto request);
+
+    // FAQ 전체 조회
+    List<FaqResponseDto> getAllFaqs();
+
+    // FAQ 카테고리별 조회
+    List<FaqResponseDto> getFaqsByCategory(Faq.FaqCategory category);
+
+    // FAQ 수정
+    FaqResponseDto updateFaq(Long faqId, FaqCreateRequestDto request);
+
+    // FAQ 노출 여부 변경
+    void toggleVisibility(Long faqId, boolean isVisible);
+
+    // FAQ 삭제 (소프트 딜리트)
+    void deleteFaq(Long faqId);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/service/impl/FaqServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/service/impl/FaqServiceImpl.java
@@ -1,0 +1,80 @@
+package co.kr.allpick.domain.admin.board.service.impl;
+
+import co.kr.allpick.domain.admin.board.dto.FaqCreateRequestDto;
+import co.kr.allpick.domain.admin.board.dto.FaqResponseDto;
+import co.kr.allpick.domain.admin.board.entity.Faq;
+import co.kr.allpick.domain.admin.board.repository.FaqRepository;
+import co.kr.allpick.domain.admin.board.service.FaqService;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FaqServiceImpl implements FaqService {
+
+    private final FaqRepository faqRepository;
+    private static final Logger logger = LogManager.getLogger(FaqServiceImpl.class);
+
+    @Override
+    @Transactional
+    public FaqResponseDto createFaq(Long adminId, FaqCreateRequestDto request) {
+        Faq faq = request.toEntity(adminId);
+        faqRepository.save(faq);
+        logger.info("[FaqServiceImpl] FAQ 등록 완료 - adminId: {}", adminId);
+        return FaqResponseDto.from(faq);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FaqResponseDto> getAllFaqs() {
+        return faqRepository.findAllByDeletedAtIsNullOrderByDisplayOrderAsc()
+                .stream()
+                .map(FaqResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FaqResponseDto> getFaqsByCategory(Faq.FaqCategory category) {
+        return faqRepository.findAllByCategoryAndDeletedAtIsNullOrderByDisplayOrderAsc(category)
+                .stream()
+                .map(FaqResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public FaqResponseDto updateFaq(Long faqId, FaqCreateRequestDto request) {
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FAQ_NOT_FOUND));
+        faq.update(request.getCategory(), request.getTitle(), request.getContent(), request.getDisplayOrder());
+        logger.info("[FaqServiceImpl] FAQ 수정 완료 - faqId: {}", faqId);
+        return FaqResponseDto.from(faq);
+    }
+
+    @Override
+    @Transactional
+    public void toggleVisibility(Long faqId, boolean isVisible) {
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FAQ_NOT_FOUND));
+        faq.toggleVisibility(isVisible);
+        logger.info("[FaqServiceImpl] FAQ 노출 여부 변경 - faqId: {}, isVisible: {}", faqId, isVisible);
+    }
+
+    @Override
+    @Transactional
+    public void deleteFaq(Long faqId) {
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FAQ_NOT_FOUND));
+        faq.delete();
+        logger.info("[FaqServiceImpl] FAQ 삭제 완료 - faqId: {}", faqId);
+    }
+}

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -43,7 +43,10 @@ public enum ErrorCode {
 
     //Admin
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_NOT_FOUND", "관리자를 찾을 수 없습니다."),
-    ADMIN_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "ADMIN_DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.");
+    ADMIN_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "ADMIN_DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
+
+    // FAQ
+    FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ_NOT_FOUND", "FAQ를 찾을 수 없습니다.");
 
 	
     // Product


### PR DESCRIPTION
## 개요
- FAQ 도메인 토대 구현 (Entity, Repository, DTO, Service)

---

## 작업 내용
- [x] 기능 추가

### 주요 변경 사항
- Controller: 없음 (AdminController 구현 후 추가 예정)
- Service: FaqService 인터페이스 및 FaqServiceImpl 구현
  - FAQ 등록, 전체 조회, 카테고리별 조회, 수정, 노출 여부 변경, 소프트 딜리트
- Repository: FaqRepository 구현
  - 소프트 딜리트 기반 전체 조회 및 카테고리 필터 조회
- 기타:
  - Faq Entity 구현 (FaqCategory Enum: DELIVERY, PAYMENT, CANCEL_REFUND, MEMBER)
  - FaqCreateRequestDto, FaqResponseDto 구현
  - ErrorCode에 FAQ_NOT_FOUND 추가

---

## 변경 전 / 후
### Before
- FAQ 관련 도메인 없음

### After
- admin/board 패키지 하위에 FAQ 도메인 토대 구성 완료
- 컨트롤러를 제외한 전체 레이어 구현 완료

---

## 머지 시 주의사항
- `ErrorCode.java`는 공용 파일로 다른 브랜치와 충돌 가능성 있음
- 머지 시 `FAQ_NOT_FOUND` 항목이 누락되지 않도록 확인 필요