### PR TITLE
feat: admin 인증 방식 분리 + 이미지 업로드 S3 버킷 관련 코드 에러해결

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/service/impl/AdminServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/service/impl/AdminServiceImpl.java
@@ -7,8 +7,8 @@ import co.kr.allpick.domain.admin.dto.AdminLoginResponseDto;
 import co.kr.allpick.domain.admin.entity.Admin;
 import co.kr.allpick.domain.admin.repository.AdminRepository;
 import co.kr.allpick.domain.admin.service.AdminService;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
 import co.kr.allpick.global.config.JwtProvider;
-import co.kr.allpick.global.config.JwtUserInfoDto;
 import co.kr.allpick.global.exception.BusinessException;
 import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -41,13 +41,13 @@ public class AdminServiceImpl implements AdminService {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
 
-        JwtUserInfoDto jwtUserInfoDto = new JwtUserInfoDto(
+        AdminJwtUserInfoDto adminJwtUserInfoDto = new AdminJwtUserInfoDto(
                 admin.getAdminId(),
                 admin.getEmail(),
-                null
+                admin.getRole()
         );
 
-        String token = jwtProvider.createToken(jwtUserInfoDto);
+        String token = jwtProvider.createToken(adminJwtUserInfoDto);
 
         logger.info("[AdminServiceImpl] 관리자 로그인 성공 - adminId: {}", admin.getAdminId());
 

--- a/src/main/java/co/kr/allpick/global/config/AdminJwtUserInfoDto.java
+++ b/src/main/java/co/kr/allpick/global/config/AdminJwtUserInfoDto.java
@@ -1,0 +1,12 @@
+package co.kr.allpick.global.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminJwtUserInfoDto {
+    private Long adminId;
+    private String email;
+    private String role;
+}

--- a/src/main/java/co/kr/allpick/global/config/AdminJwtUserInfoDto.java
+++ b/src/main/java/co/kr/allpick/global/config/AdminJwtUserInfoDto.java
@@ -1,5 +1,6 @@
 package co.kr.allpick.global.config;
 
+import co.kr.allpick.domain.admin.entity.Admin;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,5 +9,5 @@ import lombok.Getter;
 public class AdminJwtUserInfoDto {
     private Long adminId;
     private String email;
-    private String role;
+    private Admin.AdminRole role;
 }

--- a/src/main/java/co/kr/allpick/global/config/JwtProvider.java
+++ b/src/main/java/co/kr/allpick/global/config/JwtProvider.java
@@ -38,6 +38,21 @@ public class JwtProvider {
                 .compact();
     }
 
+
+    public String createToken(AdminJwtUserInfoDto adminJwtUserInfoDto) {
+        Date now = new Date();
+        long expireTime = jwtProperties.getExpirationTime();
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(adminJwtUserInfoDto.getAdminId()))
+                .claim("email", adminJwtUserInfoDto.getEmail())
+                .claim("role", adminJwtUserInfoDto.getRole().name())  // enum → String
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expireTime))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
     public Long getMemberIdFromToken(String token) {
         String subject = Jwts.parserBuilder()
                 .setSigningKey(getSigningKey())

--- a/src/main/java/co/kr/allpick/global/config/S3Config.java
+++ b/src/main/java/co/kr/allpick/global/config/S3Config.java
@@ -1,0 +1,36 @@
+package co.kr.allpick.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/co/kr/allpick/global/config/S3Properties.java
+++ b/src/main/java/co/kr/allpick/global/config/S3Properties.java
@@ -1,0 +1,14 @@
+package co.kr.allpick.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public class S3Properties {
+    private String imageBucket;
+}

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -43,12 +43,16 @@ public enum ErrorCode {
 
     //Admin
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN_NOT_FOUND", "관리자를 찾을 수 없습니다."),
-    ADMIN_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "ADMIN_DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.");
+    ADMIN_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "ADMIN_DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
 
 	
     // Product
     PRODUCT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PRODUCT_ALREADY_EXISTS", "이미 존재하는 상품입니다."),
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_NOT_FOUND", "존재하지 않는 상품입니다.");
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_NOT_FOUND", "존재하지 않는 상품입니다."),
+
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_UPLOAD_FAILED", "이미지 업로드에 실패했습니다."),
+    INVALID_FILE(HttpStatus.BAD_REQUEST, "INVALID_FILE", "파일이 없거나 비어있습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "INVALID_FILE_TYPE", "이미지 파일만 업로드 가능합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/co/kr/allpick/global/filter/JwtAuthFilter.java
+++ b/src/main/java/co/kr/allpick/global/filter/JwtAuthFilter.java
@@ -68,6 +68,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                         null,
                         Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
                 );
+
         SecurityContextHolder.getContext().setAuthentication(authentication);
         logger.info("인증 성공 - memberId: {}", memberId);
         filterChain.doFilter(request, response);

--- a/src/main/java/co/kr/allpick/global/util/S3Uploader.java
+++ b/src/main/java/co/kr/allpick/global/util/S3Uploader.java
@@ -1,0 +1,106 @@
+package co.kr.allpick.global.util;
+
+import co.kr.allpick.global.config.S3Properties;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private static final Logger logger = LogManager.getLogger(S3Uploader.class);
+
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    /**
+     * 이미지 업로드
+     * @param file 업로드할 파일
+     * @param folder 저장 폴더 (예: "products", "claims")
+     * @return S3 이미지 URL
+     */
+    public String upload(MultipartFile file, String folder) {
+        validateImageFile(file);
+
+        String fileName = buildFileName(folder, file.getOriginalFilename());
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(s3Properties.getImageBucket())
+                    .key(fileName)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(
+                    file.getInputStream(), file.getSize()));
+
+            String url = buildUrl(fileName);
+            logger.info("S3 이미지 업로드 완료 - url: {}", url);
+            return url;
+
+        } catch (IOException e) {
+            logger.error("S3 이미지 업로드 실패 - fileName: {}", fileName);
+            throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * 이미지 삭제
+     * @param imageUrl 삭제할 이미지 URL
+     */
+    public void delete(String imageUrl) {
+        String fileName = extractFileName(imageUrl);
+
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(s3Properties.getImageBucket())
+                .key(fileName)
+                .build();
+
+        s3Client.deleteObject(request);
+        logger.info("S3 이미지 삭제 완료 - fileName: {}", fileName);
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_FILE);
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    private String buildFileName(String folder, String originalFileName) {
+        String ext = extractExtension(originalFileName);
+        return folder + "/" + UUID.randomUUID() + "." + ext;
+    }
+
+    private String extractExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+        }
+        return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+    }
+
+    private String buildUrl(String fileName) {
+        return "https://" + s3Properties.getImageBucket()
+                + ".s3.amazonaws.com/" + fileName;
+    }
+
+    private String extractFileName(String imageUrl) {
+        return imageUrl.substring(imageUrl.indexOf(".amazonaws.com/") + 15);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,5 @@ spring.data.redis.port=6379
 spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 spring.cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 cloud.aws.s3.image-bucket=${S3_IMAGE_BUCKET_NAME}
+spring.cloud.aws.s3.region=ap-southeast-2
+spring.autoconfigure.exclude=io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration


### PR DESCRIPTION
## 작업 내용
- [v]기능 추가
- [v] 문서 수정

### 주요 변경 사항
JwtUserInfo와
JwtAdminInfo로 분리하여 인증 방식 분리(role 때문에)
---

## 변경 전 / 후
### Before
- 로그인 시 어드민은 role때문에 인증을 분리해야했지만 기본 유저엔 role이 없어서 인증이 안됐음.

### After
- 파일을 분리하여 유저는 유저로. 어드민은 어드민으로 인증을 받게 만듬.
- 이미지 업로드를 위해 S3 버킷과 연결했는데 sql버전이 낮아 업로드가 안되던 현상을 수정하기 위해 의존성 추가 및 수정