### PR TITLE
fix: 다른 브랜치 머지 후 s3 의존성 삭제된 부분 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'net.nurigo:sdk:4.3.2'
 
     // AWS S3 (설정 없으면 주석처리)
-    // implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
## 개요
- #44 머지된 후 bradle에서 S3 관련 의존성이 제거되어 추가했습니다.
---

## 작업 내용
- [v] 기능 추가

## 관련 이슈

- 관련 이슈: #44 
---