### PR TITLE
feat : SellerAuthServiceImplTest 관련 테스트코드 수정 및 Terms 관련 테스트코드 추가

### DIFF
--- a/src/main/java/co/kr/allpick/domain/seller/controller/SellerAuthController.java
+++ b/src/main/java/co/kr/allpick/domain/seller/controller/SellerAuthController.java
@@ -52,8 +52,8 @@ public class SellerAuthController implements SellerAuthControllerDocs {
     public ResponseEntity<ApiResponse<Void>> update(
             @RequestBody @Valid SellerUpdateRequestDto dto,
             @PathVariable("sellerId") Long sellerId,
-            @AuthenticationPrincipal JwtUserInfoDto userInfo){
-    	sellerAuthService.update(sellerId, dto);
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        sellerAuthService.update(sellerId, dto, userInfo.getMemberId());
         return ApiResponse.success("판매자 정보가 수정되었습니다.");
     }
     

--- a/src/main/java/co/kr/allpick/domain/seller/controller/SellerAuthController.java
+++ b/src/main/java/co/kr/allpick/domain/seller/controller/SellerAuthController.java
@@ -53,7 +53,7 @@ public class SellerAuthController implements SellerAuthControllerDocs {
             @RequestBody @Valid SellerUpdateRequestDto dto,
             @PathVariable("sellerId") Long sellerId,
             @AuthenticationPrincipal JwtUserInfoDto userInfo){
-    	sellerAuthService.update(sellerId, dto, userInfo.getMemberId());
+    	sellerAuthService.update(sellerId, dto);
         return ApiResponse.success("판매자 정보가 수정되었습니다.");
     }
     

--- a/src/main/java/co/kr/allpick/domain/seller/dto/SellerUpdateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/seller/dto/SellerUpdateRequestDto.java
@@ -2,7 +2,6 @@ package co.kr.allpick.domain.seller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SellerUpdateRequestDto {
-
-	@Schema(description = "판매자 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotNull(message = "판매자 ID는 필수입니다.")
-    private Long sellerId;
 
     @NotBlank
     @Schema(description = "상호명", example = "나이키 코리아",

--- a/src/main/java/co/kr/allpick/domain/seller/service/SellerAuthService.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/SellerAuthService.java
@@ -8,6 +8,6 @@ import co.kr.allpick.domain.seller.dto.SellerUpdateRequestDto;
 public interface SellerAuthService {
     void signup(SellerSignupRequestDto dto, Long memberId);
     SellerLoginResponseDto login(SellerLoginRequestDto dto);
-    void update(Long sellerId, SellerUpdateRequestDto dto, Long memberId);
+    void update(Long sellerId, SellerUpdateRequestDto dto);
     void deleteSeller(Long sellerId, Long memberId);
 }

--- a/src/main/java/co/kr/allpick/domain/seller/service/SellerAuthService.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/SellerAuthService.java
@@ -8,6 +8,6 @@ import co.kr.allpick.domain.seller.dto.SellerUpdateRequestDto;
 public interface SellerAuthService {
     void signup(SellerSignupRequestDto dto, Long memberId);
     SellerLoginResponseDto login(SellerLoginRequestDto dto);
-    void update(Long sellerId, SellerUpdateRequestDto dto);
+    void update(Long sellerId, SellerUpdateRequestDto dto, Long memberId);
     void deleteSeller(Long sellerId, Long memberId);
 }

--- a/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
@@ -35,9 +35,11 @@ public class SellerAuthServiceImpl implements SellerAuthService {
     private final JwtProvider jwtProvider;
 
     @Override
-    public void update(Long sellerId, SellerUpdateRequestDto dto) {
+    public void update(Long sellerId, SellerUpdateRequestDto dto, Long memberId) {
         Seller seller = sellerRepository.findById(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+
+        validateSellerOwner(seller, memberId);
 
         seller.updateInfo(
                 dto.getBusinessName(),

--- a/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
@@ -35,11 +35,9 @@ public class SellerAuthServiceImpl implements SellerAuthService {
     private final JwtProvider jwtProvider;
 
     @Override
-    public void update(Long sellerId, SellerUpdateRequestDto dto, Long memberId) {
+    public void update(Long sellerId, SellerUpdateRequestDto dto) {
         Seller seller = sellerRepository.findById(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
-
-        validateSellerOwner(seller, memberId);  // ← 헬퍼 메서드로 교체
 
         seller.updateInfo(
                 dto.getBusinessName(),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,6 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
-
 # JWT
 jwt.secret=${JWT_SECRET}
 jwt.expiration-time=${JWT_EXPIRATION_TIME}
@@ -17,7 +16,6 @@ jwt.expiration-time=${JWT_EXPIRATION_TIME}
 # spring.data.redis.host=[Redis EC2 퍼블릭 IP]
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
-
 
 # AWS S3
 spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
@@ -49,6 +49,7 @@ class SellerAuthServiceImplTest {
     void signup_validRequest_success() {
         // given
         Long memberId = 1L;
+        
         SellerSignupRequestDto dto = new SellerSignupRequestDto(
                 "나이키 코리아", "1234567890", "홍길동", "국민은행", "12345678901234");
 
@@ -106,6 +107,7 @@ class SellerAuthServiceImplTest {
     void update_validRequest_success() {
         // given
         Long sellerId = 1L;
+        Long memberId = 1L;
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
                 1L, "아디다스 코리아", "김철수", "신한은행", "98765432101234");
 
@@ -119,7 +121,7 @@ class SellerAuthServiceImplTest {
         given(sellerRepository.findById(sellerId)).willReturn(Optional.of(mockSeller));
 
         // when
-        sellerAuthService.update(sellerId, dto);
+        sellerAuthService.update(sellerId, dto, memberId);
 
         // then
         verify(sellerRepository, times(1)).findById(sellerId);
@@ -130,13 +132,14 @@ class SellerAuthServiceImplTest {
     void update_sellerNotFound_throwException() {
         // given
         Long sellerId = 999L;
+        Long memberId = 1L;
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
                 1L, "아디다스 코리아", "김철수", "신한은행", "98765432101234");
 
         given(sellerRepository.findById(sellerId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> sellerAuthService.update(sellerId, dto))
+        assertThatThrownBy(() -> sellerAuthService.update(sellerId, dto, memberId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.SELLER_NOT_FOUND.getMessage());
     }
@@ -235,19 +238,23 @@ class SellerAuthServiceImplTest {
     void deleteSeller_validRequest_success() {
         // given
         Long sellerId = 1L;
+        Long memberId = 1L;
+        
+        Member mockMember = Member.builder().build();
 
         Seller mockSeller = Seller.builder()
                 .businessName("나이키 코리아")
                 .representativeName("홍길동")
                 .businessNumber("1234567890")
                 .status(SellerStatus.APPROVED)
+                .member(mockMember)
                 .build();
 
         given(sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId))
                 .willReturn(Optional.of(mockSeller));
 
         // when
-        sellerAuthService.deleteSeller(sellerId);
+        sellerAuthService.deleteSeller(sellerId, memberId);
 
         // then
         verify(sellerRepository, times(1)).save(any(Seller.class));
@@ -258,12 +265,13 @@ class SellerAuthServiceImplTest {
     void deleteSeller_sellerNotFound_throwException() {
         // given
         Long sellerId = 999L;
+        Long memberId = 1L;
 
         given(sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId))
                 .willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> sellerAuthService.deleteSeller(sellerId))
+        assertThatThrownBy(() -> sellerAuthService.deleteSeller(sellerId, memberId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.SELLER_NOT_FOUND.getMessage());
     }

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
@@ -107,25 +107,20 @@ class SellerAuthServiceImplTest {
     void update_validRequest_success() {
         // given
         Long sellerId = 1L;
-        Long memberId = 1L;
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
-                1L, "아디다스 코리아", "김철수", "신한은행", "98765432101234");
-
-        Member mockMember = mock(Member.class);
-        given(mockMember.getId()).willReturn(memberId); // ✅ getId()가 memberId를 반환하도록 설정
+                "아디다스 코리아", "김철수", "신한은행", "98765432101234");
 
         Seller mockSeller = Seller.builder()
                 .businessName("나이키 코리아")
                 .representativeName("홍길동")
                 .businessNumber("1234567890")
                 .status(SellerStatus.APPROVED)
-                .member(mockMember) // ✅ member 설정
                 .build();
 
         given(sellerRepository.findById(sellerId)).willReturn(Optional.of(mockSeller));
 
         // when
-        sellerAuthService.update(sellerId, dto, memberId);
+        sellerAuthService.update(sellerId, dto);
 
         // then
         verify(sellerRepository, times(1)).findById(sellerId);
@@ -136,14 +131,13 @@ class SellerAuthServiceImplTest {
     void update_sellerNotFound_throwException() {
         // given
         Long sellerId = 999L;
-        Long memberId = 1L;
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
-                1L, "아디다스 코리아", "김철수", "신한은행", "98765432101234");
+                "아디다스 코리아", "김철수", "신한은행", "98765432101234");
 
         given(sellerRepository.findById(sellerId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> sellerAuthService.update(sellerId, dto, memberId))
+        assertThatThrownBy(() -> sellerAuthService.update(sellerId, dto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.SELLER_NOT_FOUND.getMessage());
     }
@@ -246,7 +240,7 @@ class SellerAuthServiceImplTest {
         Long memberId = 1L;
 
         Member mockMember = mock(Member.class);
-        given(mockMember.getId()).willReturn(memberId); // ✅ getId()가 memberId를 반환하도록 설정
+        given(mockMember.getId()).willReturn(memberId);
 
         Seller mockSeller = Seller.builder()
                 .businessName("나이키 코리아")

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
@@ -107,20 +107,25 @@ class SellerAuthServiceImplTest {
     void update_validRequest_success() {
         // given
         Long sellerId = 1L;
+        Long memberId = 1L;
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
                 "아디다스 코리아", "김철수", "신한은행", "98765432101234");
+
+        Member mockMember = mock(Member.class);
+        given(mockMember.getId()).willReturn(memberId);
 
         Seller mockSeller = Seller.builder()
                 .businessName("나이키 코리아")
                 .representativeName("홍길동")
                 .businessNumber("1234567890")
                 .status(SellerStatus.APPROVED)
+                .member(mockMember)
                 .build();
 
         given(sellerRepository.findById(sellerId)).willReturn(Optional.of(mockSeller));
 
         // when
-        sellerAuthService.update(sellerId, dto);
+        sellerAuthService.update(sellerId, dto, memberId);
 
         // then
         verify(sellerRepository, times(1)).findById(sellerId);
@@ -131,13 +136,14 @@ class SellerAuthServiceImplTest {
     void update_sellerNotFound_throwException() {
         // given
         Long sellerId = 999L;
+        Long memberId = 1L;
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
                 "아디다스 코리아", "김철수", "신한은행", "98765432101234");
 
         given(sellerRepository.findById(sellerId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> sellerAuthService.update(sellerId, dto))
+        assertThatThrownBy(() -> sellerAuthService.update(sellerId, dto, memberId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.SELLER_NOT_FOUND.getMessage());
     }

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
@@ -26,8 +26,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -49,7 +49,7 @@ class SellerAuthServiceImplTest {
     void signup_validRequest_success() {
         // given
         Long memberId = 1L;
-        
+
         SellerSignupRequestDto dto = new SellerSignupRequestDto(
                 "나이키 코리아", "1234567890", "홍길동", "국민은행", "12345678901234");
 
@@ -111,11 +111,15 @@ class SellerAuthServiceImplTest {
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
                 1L, "아디다스 코리아", "김철수", "신한은행", "98765432101234");
 
+        Member mockMember = mock(Member.class);
+        given(mockMember.getId()).willReturn(memberId); // ✅ getId()가 memberId를 반환하도록 설정
+
         Seller mockSeller = Seller.builder()
                 .businessName("나이키 코리아")
                 .representativeName("홍길동")
                 .businessNumber("1234567890")
                 .status(SellerStatus.APPROVED)
+                .member(mockMember) // ✅ member 설정
                 .build();
 
         given(sellerRepository.findById(sellerId)).willReturn(Optional.of(mockSeller));
@@ -166,7 +170,7 @@ class SellerAuthServiceImplTest {
 
         given(memberRepository.findByEmail(dto.getEmail())).willReturn(Optional.of(mockMember));
         given(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).willReturn(true);
-        given(sellerRepository.findByMemberId(mockMember.getId())).willReturn(Optional.of(mockSeller));
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(mockMember.getId())).willReturn(Optional.of(mockSeller));
         given(jwtProvider.createToken(any(JwtUserInfoDto.class))).willReturn("mockToken");
 
         // when
@@ -224,14 +228,15 @@ class SellerAuthServiceImplTest {
 
         given(memberRepository.findByEmail(dto.getEmail())).willReturn(Optional.of(mockMember));
         given(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).willReturn(true);
-        given(sellerRepository.findByMemberId(mockMember.getId())).willReturn(Optional.empty());
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(mockMember.getId())).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> sellerAuthService.login(dto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.NOT_SELLER.getMessage());
     }
- // ==================== 판매자 삭제 ====================
+
+    // ==================== 판매자 삭제 ====================
 
     @Test
     @DisplayName("판매자 삭제 성공")
@@ -239,8 +244,9 @@ class SellerAuthServiceImplTest {
         // given
         Long sellerId = 1L;
         Long memberId = 1L;
-        
-        Member mockMember = Member.builder().build();
+
+        Member mockMember = mock(Member.class);
+        given(mockMember.getId()).willReturn(memberId); // ✅ getId()가 memberId를 반환하도록 설정
 
         Seller mockSeller = Seller.builder()
                 .businessName("나이키 코리아")
@@ -275,5 +281,4 @@ class SellerAuthServiceImplTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.SELLER_NOT_FOUND.getMessage());
     }
-    
 }

--- a/src/test/java/co/kr/allpick/domain/terms/service/impl/TermsServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/terms/service/impl/TermsServiceImplTest.java
@@ -1,0 +1,59 @@
+package co.kr.allpick.domain.terms.service.impl;
+
+import co.kr.allpick.domain.member.entity.Terms;
+import co.kr.allpick.domain.member.repository.TermsRepository;
+import co.kr.allpick.domain.member.service.impl.TermsServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TermsServiceImplTest {
+
+    @Mock
+    TermsRepository termsRepository;
+
+    @InjectMocks
+    TermsServiceImpl termsService;
+
+    @Test
+    @DisplayName("활성 약관 목록 조회 성공")
+    void getActiveTerms_success() {
+        // given
+        Terms terms1 = Terms.builder().isActive(true).build();
+        Terms terms2 = Terms.builder().isActive(true).build();
+
+        given(termsRepository.findByIsActiveTrue()).willReturn(List.of(terms1, terms2));
+
+        // when
+        List<Terms> result = termsService.getActiveTerms();
+
+        // then
+        assertThat(result).hasSize(2);
+        verify(termsRepository, times(1)).findByIsActiveTrue();
+    }
+
+    @Test
+    @DisplayName("활성 약관 없을 경우 빈 리스트 반환")
+    void getActiveTerms_empty() {
+        // given
+        given(termsRepository.findByIsActiveTrue()).willReturn(List.of());
+
+        // when
+        List<Terms> result = termsService.getActiveTerms();
+
+        // then
+        assertThat(result).isEmpty();
+        verify(termsRepository, times(1)).findByIsActiveTrue();
+    }
+}


### PR DESCRIPTION
작업 내용

 기능 추가
 버그 수정
 리팩토링
[V] 테스트 코드 작성
 문서 수정

주요 변경 사항

Controller: 없음
Service: 없음
Repository: 없음
기타:

login_validRequest_success, login_notSeller_throwException — findByMemberId() → findByMemberIdAndDeletedAtIsNull()로 수정 (실제 서비스 메서드명과 불일치 해결)
login_validRequest_success, login_notSeller_throwException — Member 빌더에서 불필요한 .role(Role.SELLER) 제거 (Role 필드 삭제됨)
update_validRequest_success, deleteSeller_validRequest_success — Member.builder() → mock(Member.class) + given(mockMember.getId()).willReturn(memberId) 로 변경하여 validateSellerOwner() 호출 시 NPE 방지
update_validRequest_success, deleteSeller_validRequest_success — Seller 빌더에 mockMember 세팅 추가




관련 이슈

관련 이슈: 없음


변경 전 / 후
Before

findByMemberId()로 stub 설정하여 실제 서비스의 findByMemberIdAndDeletedAtIsNull()과 불일치 → 로그인 성공 테스트 실패
Member.builder()로 생성한 객체의 id가 null이어서 validateSellerOwner() 호출 시 NPE 발생
삭제된 Role 필드를 테스트에서 계속 참조하여 컴파일 에러 발생

After

findByMemberIdAndDeletedAtIsNull()으로 수정하여 실제 구현체와 일치
mock(Member.class)로 교체하고 getId()가 memberId를 반환하도록 설정하여 validateSellerOwner() 정상 동작
Role 관련 코드 전면 제거

<img width="485" height="355" alt="image" src="https://github.com/user-attachments/assets/ba157c2a-ac13-4b8d-8896-eb2462766267" />

SellerAuthServiceImpl 테스트 코드 수정 (mock 객체 및 메서드명 불일치 해결)


작업 내용

 기능 추가
 버그 수정
 리팩토링
[V] 테스트 코드 작성
 문서 수정

주요 변경 사항

Controller: 없음
Service: 없음
Repository: 없음
기타:

login_validRequest_success, login_notSeller_throwException — findByMemberId() → findByMemberIdAndDeletedAtIsNull()로 수정 (실제 서비스 메서드명과 불일치 해결)
update_validRequest_success, deleteSeller_validRequest_success — Member.builder() → mock(Member.class) + given(mockMember.getId()).willReturn(memberId) 로 변경하여 validateSellerOwner() 호출 시 NPE 방지
update_validRequest_success, deleteSeller_validRequest_success — Seller 빌더에 mockMember 세팅 추가




관련 이슈

관련 이슈: 없음


변경 전 / 후
Before

findByMemberId()로 stub 설정하여 실제 서비스의 findByMemberIdAndDeletedAtIsNull()과 불일치 → 로그인 성공 테스트 실패
Member.builder()로 생성한 객체의 id가 null이어서 validateSellerOwner() 호출 시 NPE 발생

After

findByMemberIdAndDeletedAtIsNull()으로 수정하여 실제 구현체와 일치
mock(Member.class)로 교체하고 getId()가 memberId를 반환하도록 설정하여 validateSellerOwner() 정상 동작