### PR TITLE
feat: FAQ, Notice 컨트롤러 구현 및 Inquiry 관리자 JWT 수정

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/board/controller/FaqController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/controller/FaqController.java
@@ -1,0 +1,70 @@
+package co.kr.allpick.domain.admin.board.controller;
+
+import co.kr.allpick.domain.admin.board.controller.docs.FaqControllerDocs;
+import co.kr.allpick.domain.admin.board.dto.FaqCreateRequestDto;
+import co.kr.allpick.domain.admin.board.dto.FaqResponseDto;
+import co.kr.allpick.domain.admin.board.entity.Faq;
+import co.kr.allpick.domain.admin.board.service.FaqService;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/faqs")
+public class FaqController implements FaqControllerDocs {
+
+    private final FaqService faqService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<FaqResponseDto>> createFaq(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @RequestBody @Valid FaqCreateRequestDto request) {
+        return ApiResponse.success("FAQ가 등록되었습니다.", faqService.createFaq(adminInfo.getAdminId(), request));
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FaqResponseDto>>> getAllFaqs() {
+        return ApiResponse.success("FAQ 목록 조회 성공.", faqService.getAllFaqs());
+    }
+
+    @Override
+    @GetMapping("/category/{category}")
+    public ResponseEntity<ApiResponse<List<FaqResponseDto>>> getFaqsByCategory(
+            @PathVariable("category") Faq.FaqCategory category) {
+        return ApiResponse.success("카테고리별 FAQ 조회 성공.", faqService.getFaqsByCategory(category));
+    }
+
+    @Override
+    @PutMapping("/{faqId}")
+    public ResponseEntity<ApiResponse<FaqResponseDto>> updateFaq(
+            @PathVariable("faqId") Long faqId,
+            @RequestBody @Valid FaqCreateRequestDto request) {
+        return ApiResponse.success("FAQ가 수정되었습니다.", faqService.updateFaq(faqId, request));
+    }
+
+    @Override
+    @PatchMapping("/{faqId}/visibility")
+    public ResponseEntity<ApiResponse<Void>> toggleVisibility(
+            @PathVariable("faqId") Long faqId,
+            @RequestParam("isVisible") boolean isVisible) {
+        faqService.toggleVisibility(faqId, isVisible);
+        return ApiResponse.success("FAQ 노출 여부가 변경되었습니다.", null);
+    }
+
+    @Override
+    @DeleteMapping("/{faqId}")
+    public ResponseEntity<ApiResponse<Void>> deleteFaq(
+            @PathVariable("faqId") Long faqId) {
+        faqService.deleteFaq(faqId);
+        return ApiResponse.success("FAQ가 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/controller/NoticeController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/controller/NoticeController.java
@@ -1,0 +1,60 @@
+package co.kr.allpick.domain.admin.board.controller;
+
+import co.kr.allpick.domain.admin.board.controller.docs.NoticeControllerDocs;
+import co.kr.allpick.domain.admin.board.dto.NoticeCreateRequestDto;
+import co.kr.allpick.domain.admin.board.dto.NoticeResponseDto;
+import co.kr.allpick.domain.admin.board.service.NoticeService;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController implements NoticeControllerDocs {
+
+    private final NoticeService noticeService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<NoticeResponseDto>> createNotice(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @RequestBody @Valid NoticeCreateRequestDto request) {
+        return ApiResponse.success("공지사항이 등록되었습니다.", noticeService.createNotice(adminInfo.getAdminId(), request));
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NoticeResponseDto>>> getAllNotices() {
+        return ApiResponse.success("공지사항 목록 조회 성공.", noticeService.getAllNotices());
+    }
+
+    @Override
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<NoticeResponseDto>> getNoticeById(
+            @PathVariable("noticeId") Long noticeId) {
+        return ApiResponse.success("공지사항 조회 성공.", noticeService.getNoticeById(noticeId));
+    }
+
+    @Override
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<NoticeResponseDto>> updateNotice(
+            @PathVariable("noticeId") Long noticeId,
+            @RequestBody @Valid NoticeCreateRequestDto request) {
+        return ApiResponse.success("공지사항이 수정되었습니다.", noticeService.updateNotice(noticeId, request));
+    }
+
+    @Override
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(
+            @PathVariable("noticeId") Long noticeId) {
+        noticeService.deleteNotice(noticeId);
+        return ApiResponse.success("공지사항이 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/controller/docs/FaqControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/controller/docs/FaqControllerDocs.java
@@ -1,0 +1,73 @@
+package co.kr.allpick.domain.admin.board.controller.docs;
+
+import co.kr.allpick.domain.admin.board.dto.FaqCreateRequestDto;
+import co.kr.allpick.domain.admin.board.dto.FaqResponseDto;
+import co.kr.allpick.domain.admin.board.entity.Faq;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "FAQ", description = "FAQ API")
+public interface FaqControllerDocs {
+
+    @Operation(summary = "FAQ 등록", description = "관리자가 FAQ를 등록합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "FAQ 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검사 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    ResponseEntity<ApiResponse<FaqResponseDto>> createFaq(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @RequestBody @Valid FaqCreateRequestDto request);
+
+    @Operation(summary = "FAQ 전체 조회", description = "등록된 모든 FAQ를 조회합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "FAQ 목록 조회 성공")
+    ResponseEntity<ApiResponse<List<FaqResponseDto>>> getAllFaqs();
+
+    @Operation(summary = "FAQ 카테고리별 조회", description = "카테고리(DELIVERY, PAYMENT, CANCEL_REFUND, MEMBER)별로 FAQ를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리별 FAQ 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 카테고리")
+    })
+    ResponseEntity<ApiResponse<List<FaqResponseDto>>> getFaqsByCategory(
+            @Parameter(description = "FAQ 카테고리 (DELIVERY, PAYMENT, CANCEL_REFUND, MEMBER)")
+            @PathVariable("category") Faq.FaqCategory category);
+
+    @Operation(summary = "FAQ 수정", description = "관리자가 FAQ를 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "FAQ 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검사 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 FAQ")
+    })
+    ResponseEntity<ApiResponse<FaqResponseDto>> updateFaq(
+            @Parameter(description = "FAQ ID") @PathVariable("faqId") Long faqId,
+            @RequestBody @Valid FaqCreateRequestDto request);
+
+    @Operation(summary = "FAQ 노출 여부 변경", description = "관리자가 FAQ의 노출 여부를 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "노출 여부 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 FAQ")
+    })
+    ResponseEntity<ApiResponse<Void>> toggleVisibility(
+            @Parameter(description = "FAQ ID") @PathVariable("faqId") Long faqId,
+            @Parameter(description = "노출 여부 (true: 노출, false: 숨김)") @RequestParam("isVisible") boolean isVisible);
+
+    @Operation(summary = "FAQ 삭제", description = "관리자가 FAQ를 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "FAQ 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 FAQ")
+    })
+    ResponseEntity<ApiResponse<Void>> deleteFaq(
+            @Parameter(description = "FAQ ID") @PathVariable("faqId") Long faqId);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/board/controller/docs/NoticeControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/board/controller/docs/NoticeControllerDocs.java
@@ -1,0 +1,61 @@
+package co.kr.allpick.domain.admin.board.controller.docs;
+
+import co.kr.allpick.domain.admin.board.dto.NoticeCreateRequestDto;
+import co.kr.allpick.domain.admin.board.dto.NoticeResponseDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Notice", description = "공지사항 API")
+public interface NoticeControllerDocs {
+
+    @Operation(summary = "공지사항 등록", description = "관리자가 공지사항을 등록합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지사항 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검사 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    ResponseEntity<ApiResponse<NoticeResponseDto>> createNotice(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @RequestBody @Valid NoticeCreateRequestDto request);
+
+    @Operation(summary = "공지사항 전체 조회", description = "등록된 모든 공지사항을 조회합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지사항 목록 조회 성공")
+    ResponseEntity<ApiResponse<List<NoticeResponseDto>>> getAllNotices();
+
+    @Operation(summary = "공지사항 단건 조회", description = "공지사항 ID로 상세 내용을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지사항 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 공지사항")
+    })
+    ResponseEntity<ApiResponse<NoticeResponseDto>> getNoticeById(
+            @Parameter(description = "공지사항 ID") @PathVariable("noticeId") Long noticeId);
+
+    @Operation(summary = "공지사항 수정", description = "관리자가 공지사항을 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지사항 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검사 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 공지사항")
+    })
+    ResponseEntity<ApiResponse<NoticeResponseDto>> updateNotice(
+            @Parameter(description = "공지사항 ID") @PathVariable("noticeId") Long noticeId,
+            @RequestBody @Valid NoticeCreateRequestDto request);
+
+    @Operation(summary = "공지사항 삭제", description = "관리자가 공지사항을 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지사항 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 공지사항")
+    })
+    ResponseEntity<ApiResponse<Void>> deleteNotice(
+            @Parameter(description = "공지사항 ID") @PathVariable("noticeId") Long noticeId);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/InquiryController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/InquiryController.java
@@ -7,6 +7,7 @@ import co.kr.allpick.domain.admin.product.dto.InquiryCreateRequestDto;
 import co.kr.allpick.domain.admin.product.dto.InquiryResponseDto;
 import co.kr.allpick.domain.admin.product.service.InquiryService;
 import co.kr.allpick.global.response.ApiResponse;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
 import co.kr.allpick.global.config.JwtUserInfoDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -55,9 +56,8 @@ public class InquiryController implements InquiryControllerDocs {
     public ResponseEntity<ApiResponse<InquiryAnswerResponseDto>> addAdminAnswer(
             @PathVariable("inquiryId") Long inquiryId,
             @RequestBody @Valid InquiryAnswerRequestDto request,
-            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
-        // TODO: 관리자 JWT 구현 후 adminId 교체 예정
-        return ApiResponse.success("답변이 등록되었습니다.", inquiryService.addAnswer(inquiryId, request, userInfo.getMemberId(), null));
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo) {
+        return ApiResponse.success("답변이 등록되었습니다.", inquiryService.addAnswer(inquiryId, request, adminInfo.getAdminId(), null));
     }
 
     @Override

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/InquiryControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/InquiryControllerDocs.java
@@ -4,6 +4,7 @@ import co.kr.allpick.domain.admin.product.dto.InquiryAnswerRequestDto;
 import co.kr.allpick.domain.admin.product.dto.InquiryAnswerResponseDto;
 import co.kr.allpick.domain.admin.product.dto.InquiryCreateRequestDto;
 import co.kr.allpick.domain.admin.product.dto.InquiryResponseDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
 import co.kr.allpick.global.config.JwtUserInfoDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -45,11 +46,11 @@ public interface InquiryControllerDocs {
     @Operation(summary = "전체 문의 목록 조회", description = "관리자가 전체 문의 목록을 조회합니다.")
     ResponseEntity<co.kr.allpick.global.response.ApiResponse<List<InquiryResponseDto>>> getAllInquiries();
 
-    @Operation(summary = "관리자 답변 등록", description = "관리자가 JWT 토큰 기반으로 답변을 등록합니다. (관리자 JWT 구현 후 연결 예정)")
+    @Operation(summary = "관리자 답변 등록", description = "관리자가 JWT 토큰 기반으로 답변을 등록합니다.")
     ResponseEntity<co.kr.allpick.global.response.ApiResponse<InquiryAnswerResponseDto>> addAdminAnswer(
             @Parameter(description = "문의 ID") @PathVariable("inquiryId") Long inquiryId,
             @RequestBody @Valid InquiryAnswerRequestDto request,
-            @AuthenticationPrincipal JwtUserInfoDto userInfo);
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo);
 
     @Operation(summary = "판매자 답변 등록", description = "판매자가 JWT 토큰 기반으로 답변을 등록합니다. (판매자 JWT 구현 후 연결 예정)")
     ResponseEntity<co.kr.allpick.global.response.ApiResponse<InquiryAnswerResponseDto>> addSellerAnswer(

--- a/src/test/java/co/kr/allpick/domain/admin/board/service/impl/FaqServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/board/service/impl/FaqServiceImplTest.java
@@ -1,0 +1,191 @@
+package co.kr.allpick.domain.admin.board.service.impl;
+
+import co.kr.allpick.domain.admin.board.dto.FaqCreateRequestDto;
+import co.kr.allpick.domain.admin.board.dto.FaqResponseDto;
+import co.kr.allpick.domain.admin.board.entity.Faq;
+import co.kr.allpick.domain.admin.board.repository.FaqRepository;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+public class FaqServiceImplTest {
+
+    @InjectMocks
+    private FaqServiceImpl faqService;
+
+    @Mock
+    private FaqRepository faqRepository;
+
+    // ─── 픽스처 ───
+
+    private FaqCreateRequestDto createDto() {
+        return new FaqCreateRequestDto(
+                Faq.FaqCategory.DELIVERY,
+                "배송은 얼마나 걸리나요?",
+                "평균 2~3일 소요됩니다.",
+                1
+        );
+    }
+
+    private Faq createFaq() {
+        return Faq.builder()
+                .adminId(1L)
+                .category(Faq.FaqCategory.DELIVERY)
+                .title("배송은 얼마나 걸리나요?")
+                .content("평균 2~3일 소요됩니다.")
+                .displayOrder(1)
+                .build();
+    }
+
+    // ==================== createFaq ====================
+
+    @Test
+    @DisplayName("FAQ 등록 성공")
+    void createFaq_success() {
+        // given
+        Long adminId = 1L;
+        FaqCreateRequestDto dto = createDto();
+
+        // when
+        FaqResponseDto result = faqService.createFaq(adminId, dto);
+
+        // then
+        then(faqRepository).should().save(any(Faq.class));
+        assertThat(result.getTitle()).isEqualTo(dto.getTitle());
+    }
+
+    // ==================== getAllFaqs ====================
+
+    @Test
+    @DisplayName("FAQ 전체 조회 성공")
+    void getAllFaqs_success() {
+        // given
+        given(faqRepository.findAllByDeletedAtIsNullOrderByDisplayOrderAsc())
+                .willReturn(List.of(createFaq()));
+
+        // when
+        List<FaqResponseDto> result = faqService.getAllFaqs();
+
+        // then
+        assertThat(result).hasSize(1);
+    }
+
+    // ==================== getFaqsByCategory ====================
+
+    @Test
+    @DisplayName("카테고리별 FAQ 조회 성공")
+    void getFaqsByCategory_success() {
+        // given
+        given(faqRepository.findAllByCategoryAndDeletedAtIsNullOrderByDisplayOrderAsc(Faq.FaqCategory.DELIVERY))
+                .willReturn(List.of(createFaq()));
+
+        // when
+        List<FaqResponseDto> result = faqService.getFaqsByCategory(Faq.FaqCategory.DELIVERY);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCategory()).isEqualTo(Faq.FaqCategory.DELIVERY);
+    }
+
+    // ==================== updateFaq ====================
+
+    @Test
+    @DisplayName("FAQ 수정 성공")
+    void updateFaq_success() {
+        // given
+        Long faqId = 1L;
+        FaqCreateRequestDto dto = createDto();
+        given(faqRepository.findById(faqId)).willReturn(Optional.of(createFaq()));
+
+        // when
+        FaqResponseDto result = faqService.updateFaq(faqId, dto);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo(dto.getTitle());
+    }
+
+    @Test
+    @DisplayName("FAQ 수정 실패 - 존재하지 않는 FAQ")
+    void updateFaq_notFound() {
+        // given
+        given(faqRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> faqService.updateFaq(999L, createDto()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FAQ_NOT_FOUND);
+    }
+
+    // ==================== toggleVisibility ====================
+
+    @Test
+    @DisplayName("FAQ 노출 여부 변경 성공")
+    void toggleVisibility_success() {
+        // given
+        Long faqId = 1L;
+        given(faqRepository.findById(faqId)).willReturn(Optional.of(createFaq()));
+
+        // when
+        faqService.toggleVisibility(faqId, false);
+
+        // then - 예외 없이 정상 실행 확인
+        then(faqRepository).should().findById(faqId);
+    }
+
+    @Test
+    @DisplayName("FAQ 노출 여부 변경 실패 - 존재하지 않는 FAQ")
+    void toggleVisibility_notFound() {
+        // given
+        given(faqRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> faqService.toggleVisibility(999L, false))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FAQ_NOT_FOUND);
+    }
+
+    // ==================== deleteFaq ====================
+
+    @Test
+    @DisplayName("FAQ 삭제 성공")
+    void deleteFaq_success() {
+        // given
+        Long faqId = 1L;
+        given(faqRepository.findById(faqId)).willReturn(Optional.of(createFaq()));
+
+        // when
+        faqService.deleteFaq(faqId);
+
+        // then
+        then(faqRepository).should().findById(faqId);
+    }
+
+    @Test
+    @DisplayName("FAQ 삭제 실패 - 존재하지 않는 FAQ")
+    void deleteFaq_notFound() {
+        // given
+        given(faqRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> faqService.deleteFaq(999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FAQ_NOT_FOUND);
+    }
+}
+
+


### PR DESCRIPTION
## 개요
- FAQ, 공지사항 관리자 API 컨트롤러 구현 및 Inquiry 답변 API 관리자 JWT 적용

---

## 작업 내용
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller:
  - `FaqController` 신규 구현 (등록/전체조회/카테고리조회/수정/노출여부변경/삭제)
  - `NoticeController` 신규 구현 (등록/전체조회/단건조회/수정/삭제)
  - `InquiryController` - `addAdminAnswer()` 관리자 JWT 적용 (`JwtUserInfoDto` → `AdminJwtUserInfoDto`)
- Service: 없음
- Repository: 없음
- 기타:
  - `FaqControllerDocs`, `NoticeControllerDocs` Swagger 문서 작성
  - `InquiryControllerDocs` - `addAdminAnswer()` 시그니처 수정

---

## 관련 이슈
- 관련 이슈: #55 

---

## 변경 전 / 후
### Before
- `FaqControllerDocs`, `NoticeControllerDocs`가 빈 인터페이스로만 존재하고 컨트롤러 미구현
- `InquiryController.addAdminAnswer()`가 회원 JWT(`JwtUserInfoDto`)로 관리자 ID를 처리하는 TODO 상태

### After
- FAQ, 공지사항 CRUD API 구현 완료, 등록/수정 엔드포인트는 `AdminJwtUserInfoDto`로 관리자 인증
- `InquiryController.addAdminAnswer()`가 `AdminJwtUserInfoDto.getAdminId()`로 정상 처리