### PR TITLE
feat : 클레임 판매자 승인/ 거부 구현 추가

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/ClaimController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/ClaimController.java
@@ -79,4 +79,21 @@ public class ClaimController implements ClaimControllerDocs {
         claimService.cancelClaim(claimId, userInfo.getMemberId());
         return ApiResponse.success("클레임이 취소되었습니다.", null);
     }
+    @Override
+    @PatchMapping("/{claimId}/approve")
+    public ResponseEntity<ApiResponse<ClaimResponseDto>> approveClaim(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable("claimId") Long claimId) {
+        return ApiResponse.success("클레임이 승인되었습니다.", claimService.approveClaim(claimId, userInfo.getMemberId()));
+    }
+
+    @Override
+    @PatchMapping("/{claimId}/seller-reject")
+    public ResponseEntity<ApiResponse<ClaimResponseDto>> rejectClaimBySeller(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable("claimId") Long claimId,
+            @RequestBody @Valid ClaimRejectRequestDto request) {
+        return ApiResponse.success("클레임이 거부되었습니다.", claimService.rejectClaimBySeller(claimId, request, userInfo.getMemberId()));
+    }
 }
+

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/ClaimController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/ClaimController.java
@@ -95,5 +95,12 @@ public class ClaimController implements ClaimControllerDocs {
             @RequestBody @Valid ClaimRejectRequestDto request) {
         return ApiResponse.success("클레임이 거부되었습니다.", claimService.rejectClaimBySeller(claimId, request, userInfo.getMemberId()));
     }
+    
+    @GetMapping("/seller")
+    public ResponseEntity<ApiResponse<List<ClaimResponseDto>>> getSellerClaims(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        return ApiResponse.success("판매자 클레임 목록 조회 성공",
+                claimService.getSellerClaims(userInfo.getMemberId()));
+    }
 }
 

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
@@ -48,6 +48,14 @@ public interface ClaimControllerDocs {
     ResponseEntity<ApiResponse<List<ClaimResponseDto>>> getAllClaims(
             @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo);
 
+    @Operation(summary = "판매자 클레임 목록 조회", description = "JWT 토큰으로 인증된 판매자의 클레임 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "판매자 클레임 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 판매자")
+    })
+    ResponseEntity<ApiResponse<List<ClaimResponseDto>>> getSellerClaims(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo);
     @Operation(summary = "클레임 상태 변경", description = "관리자 또는 판매자가 클레임 상태를 변경합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "클레임 상태 변경 성공"),

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
@@ -80,4 +80,27 @@ public interface ClaimControllerDocs {
     ResponseEntity<ApiResponse<Void>> cancelClaim(
             @Parameter(description = "클레임 ID") @PathVariable("claimId") Long claimId,
             @AuthenticationPrincipal JwtUserInfoDto userInfo);
+    
+    @Operation(summary = "클레임 승인 (판매자)", description = "판매자가 자신의 상품 클레임을 승인합니다. SUBMITTED → IN_PROGRESS")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "클레임 승인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "접수 상태가 아닌 클레임"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 클레임에 대한 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 클레임 또는 판매자")
+    })
+    ResponseEntity<ApiResponse<ClaimResponseDto>> approveClaim(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @Parameter(description = "클레임 ID") @PathVariable("claimId") Long claimId);
+
+    @Operation(summary = "클레임 거부 (판매자)", description = "판매자가 자신의 상품 클레임을 거부합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "클레임 거부 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 완료/거부/취소된 클레임"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 클레임에 대한 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 클레임 또는 판매자")
+    })
+    ResponseEntity<ApiResponse<ClaimResponseDto>> rejectClaimBySeller(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @Parameter(description = "클레임 ID") @PathVariable("claimId") Long claimId,
+            @RequestBody @Valid ClaimRejectRequestDto request);
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/repository/ClaimRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/repository/ClaimRepository.java
@@ -2,6 +2,9 @@ package co.kr.allpick.domain.admin.product.repository;
 
 import co.kr.allpick.domain.admin.product.entity.Claim;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface ClaimRepository extends JpaRepository<Claim, Long> {
@@ -14,4 +17,15 @@ public interface ClaimRepository extends JpaRepository<Claim, Long> {
 
     // 활성 클레임 존재 여부 확인 (취소/거부 제외)
     boolean existsByOrderItemIdAndStatusNotIn(Long orderItemId, List<Claim.ClaimStatus> statuses);
+    
+    @Query("SELECT c FROM Claim c WHERE c.memberId = :memberId AND c.deletedAt IS NULL")
+    List<Claim> findByMemberId(@Param("memberId") Long memberId);
+    
+    @Query("SELECT c FROM Claim c " +
+    	       "JOIN OrderItem oi ON c.orderItemId = oi.id " +
+    	       "JOIN oi.product p " +
+    	       "JOIN p.seller s " +
+    	       "WHERE s.sellerId = :sellerId " +
+    	       "AND c.deletedAt IS NULL")
+    	List<Claim> findBySellerIdAndDeletedAtIsNull(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
@@ -30,9 +30,9 @@ public interface ClaimService {
     // 클레임 취소 (회원)
     void cancelClaim(Long claimId, Long memberId);
     
- // 클레임 승인 (관리자/판매자)
+    // 클레임 승인 (관리자/판매자)
     ClaimResponseDto approveClaim(Long claimId, Long memberId);
     
- // 클레임 거부 (판매자)
+    // 클레임 거부 (판매자)
     ClaimResponseDto rejectClaimBySeller(Long claimId, ClaimRejectRequestDto request, Long memberId);
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
@@ -29,4 +29,10 @@ public interface ClaimService {
 
     // 클레임 취소 (회원)
     void cancelClaim(Long claimId, Long memberId);
+    
+ // 클레임 승인 (관리자/판매자)
+    ClaimResponseDto approveClaim(Long claimId, Long memberId);
+    
+ // 클레임 거부 (판매자)
+    ClaimResponseDto rejectClaimBySeller(Long claimId, ClaimRejectRequestDto request, Long memberId);
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
@@ -35,4 +35,9 @@ public interface ClaimService {
     
     // 클레임 거부 (판매자)
     ClaimResponseDto rejectClaimBySeller(Long claimId, ClaimRejectRequestDto request, Long memberId);
+    
+    // 판매자 클레임 목록 조회
+    List<ClaimResponseDto> getSellerClaims(Long memberId);
+    
+    
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import co.kr.allpick.domain.seller.repository.SellerRepository;
 
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,7 @@ public class ClaimServiceImpl implements ClaimService {
     private final ClaimRepository claimRepository;
     private final MemberRepository memberRepository;
     private final OrderItemRepository orderItemRepository;
+    private final SellerRepository sellerRepository;
 
     // 1. 클레임 등록
     @Override
@@ -164,5 +166,64 @@ public class ClaimServiceImpl implements ClaimService {
 
         claim.reject(request.getRejectReason());
         return ClaimResponseDto.from(claim);
+    }
+ // ✅ 8. 클레임 승인 (판매자) SUBMITTED → IN_PROGRESS
+    @Override
+    @Transactional
+    public ClaimResponseDto approveClaim(Long claimId, Long memberId) {
+        Claim claim = claimRepository.findById(claimId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLAIM_NOT_FOUND));
+
+        validateSellerClaimOwnership(claim, memberId);
+
+        if (claim.getStatus() != Claim.ClaimStatus.SUBMITTED) {
+            throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
+        }
+
+        claim.updateStatus(Claim.ClaimStatus.IN_PROGRESS);
+        logger.info("[ClaimService] 판매자 클레임 승인 - claimId: {}, memberId: {}", claimId, memberId);
+        return ClaimResponseDto.from(claim);
+    }
+
+    // ✅ 9. 클레임 거부 (판매자)
+    @Override
+    @Transactional
+    public ClaimResponseDto rejectClaimBySeller(Long claimId, ClaimRejectRequestDto request, Long memberId) {
+        Claim claim = claimRepository.findById(claimId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLAIM_NOT_FOUND));
+
+        validateSellerClaimOwnership(claim, memberId);
+        validateRejectableStatus(claim);
+
+        claim.reject(request.getRejectReason());
+        logger.info("[ClaimService] 판매자 클레임 거부 - claimId: {}, memberId: {}", claimId, memberId);
+        return ClaimResponseDto.from(claim);
+    }
+
+    // ✅ 판매자 소유권 검증: Claim → OrderItem → Product → Seller → Member.id
+    private void validateSellerClaimOwnership(Claim claim, Long memberId) {
+        sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+
+        OrderItem orderItem = orderItemRepository.findById(claim.getOrderItemId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+        Long productOwnerMemberId = orderItem.getProduct().getSeller().getMember().getId();
+        if (!productOwnerMemberId.equals(memberId)) {
+            throw new BusinessException(ErrorCode.CLAIM_UNAUTHORIZED);
+        }
+    }
+
+    // ✅ 거부 가능 상태 검증 공통 메서드 (관리자/판매자 공통 사용)
+    private void validateRejectableStatus(Claim claim) {
+        if (claim.getStatus() == Claim.ClaimStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.CLAIM_ALREADY_COMPLETED);
+        }
+        if (claim.getStatus() == Claim.ClaimStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.CLAIM_ALREADY_CANCELLED);
+        }
+        if (claim.getStatus() == Claim.ClaimStatus.REJECTED) {
+            throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
+        }
     }
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
@@ -17,6 +17,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import co.kr.allpick.domain.seller.entity.Seller;
+import co.kr.allpick.domain.seller.entity.SellerStatus;
 import co.kr.allpick.domain.seller.repository.SellerRepository;
 
 import java.util.List;
@@ -201,8 +204,10 @@ public class ClaimServiceImpl implements ClaimService {
     }
 
     private void validateSellerClaimOwnership(Claim claim, Long memberId) {
-        sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+        // 판매자 등록 여부 먼저 확인
+        if (!sellerRepository.existsByMemberIdAndDeletedAtIsNull(memberId)) {
+            throw new BusinessException(ErrorCode.NOT_SELLER);
+        }
 
         OrderItem orderItem = orderItemRepository.findByIdWithSellerMember(claim.getOrderItemId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND));
@@ -223,5 +228,22 @@ public class ClaimServiceImpl implements ClaimService {
         if (claim.getStatus() == Claim.ClaimStatus.REJECTED) {
             throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
         }
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public List<ClaimResponseDto> getSellerClaims(Long memberId) {
+        // 판매자 여부 + APPROVED 상태 확인
+        Seller seller = sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_SELLER));
+
+        if (seller.getStatus() != SellerStatus.APPROVED) {
+            throw new BusinessException(ErrorCode.NOT_SELLER);
+        }
+
+        // 판매자 확인 후 클레임 조회
+        return claimRepository.findBySellerIdAndDeletedAtIsNull(seller.getSellerId())
+                .stream()
+                .map(ClaimResponseDto::from)
+                .toList();
     }
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
@@ -200,12 +200,11 @@ public class ClaimServiceImpl implements ClaimService {
         return ClaimResponseDto.from(claim);
     }
 
-    // ✅ 판매자 소유권 검증: Claim → OrderItem → Product → Seller → Member.id
     private void validateSellerClaimOwnership(Claim claim, Long memberId) {
         sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
 
-        OrderItem orderItem = orderItemRepository.findById(claim.getOrderItemId())
+        OrderItem orderItem = orderItemRepository.findByIdWithSellerMember(claim.getOrderItemId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND));
 
         Long productOwnerMemberId = orderItem.getProduct().getSeller().getMember().getId();
@@ -214,7 +213,6 @@ public class ClaimServiceImpl implements ClaimService {
         }
     }
 
-    // ✅ 거부 가능 상태 검증 공통 메서드 (관리자/판매자 공통 사용)
     private void validateRejectableStatus(Claim claim) {
         if (claim.getStatus() == Claim.ClaimStatus.COMPLETED) {
             throw new BusinessException(ErrorCode.CLAIM_ALREADY_COMPLETED);

--- a/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
@@ -1,13 +1,19 @@
 package co.kr.allpick.domain.order.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 
 import co.kr.allpick.domain.order.entity.OrderItem;
 
+
 @Component("orderItemRepositoryHandler")
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     List<OrderItem> findByOrder_OrderId(Long orderId);
+    @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product p JOIN FETCH p.seller s JOIN FETCH s.member WHERE oi.orderItemId = :id")
+    Optional<OrderItem> findByIdWithSellerMember(@Param("id") Long id);
 }

--- a/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
@@ -1,5 +1,6 @@
 package co.kr.allpick.domain.order.repository;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +17,7 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     List<OrderItem> findByOrder_OrderId(Long orderId);
     @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product p JOIN FETCH p.seller s JOIN FETCH s.member WHERE oi.orderItemId = :id")
     Optional<OrderItem> findByIdWithSellerMember(@Param("id") Long id);
+    
+    @Query("SELECT SUM(oi.totalPrice) FROM OrderItem oi WHERE oi.order.orderId = :orderId")
+    BigDecimal sumTotalPriceByOrderId(@Param("orderId") Long orderId);
 }

--- a/src/main/java/co/kr/allpick/domain/order/repository/OrderRepository.java
+++ b/src/main/java/co/kr/allpick/domain/order/repository/OrderRepository.java
@@ -9,26 +9,31 @@ import org.springframework.data.repository.query.Param;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     boolean existsByOrderNumber(String orderNumber);
-
-    boolean existsByDeliveryAddress_AddressId(Long addressId);
+    
+    @Query("SELECT COUNT(o) > 0 FROM Order o WHERE o.deliveryAddress.addressId = :addressId")
+    boolean existsByAddressId(Long addressId);
 
     @EntityGraph(attributePaths = {"orderItems"})
     List<Order> findByMemberIdOrderByOrderedAtDesc(Long memberId);
     
+    @Query("SELECT o FROM Order o JOIN FETCH o.orderItems WHERE o.orderId = :orderId")
+    Optional<Order> findByIdWithItems(@Param("orderId") Long orderId);
+    
+    boolean existsByDeliveryAddress_AddressId(Long addressId);
     @Query("""
-    	    SELECT o.member.id, SUM(o.totalAmount)
-    	    FROM Order o
-    	    WHERE o.orderedAt >= :start
-    	      AND o.orderedAt < :end
-    	      AND o.status = co.kr.allpick.domain.order.entity.Order.OrderStatus.DELIVERED
-    	    GROUP BY o.member.id
-    	    """)
-    	List<Object[]> sumDeliveredAmountByMemberBetween(
-    	        @Param("start") LocalDateTime start,
-    	        @Param("end") LocalDateTime end
-    	);
+            SELECT o.member.id, SUM(o.totalAmount)
+            FROM Order o
+            WHERE o.orderedAt >= :start
+              AND o.orderedAt < :end
+              AND o.status = co.kr.allpick.domain.order.entity.Order.OrderStatus.DELIVERED
+            GROUP BY o.member.id
+            """)
+    List<Object[]> sumDeliveredAmountByMemberBetween(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
     
 }

--- a/src/main/java/co/kr/allpick/domain/order/repository/OrderRepository.java
+++ b/src/main/java/co/kr/allpick/domain/order/repository/OrderRepository.java
@@ -13,18 +13,18 @@ import java.util.List;
 public interface OrderRepository extends JpaRepository<Order, Long> {
     boolean existsByOrderNumber(String orderNumber);
 
-    boolean existsByAddressId(Long addressId);
+    boolean existsByDeliveryAddress_AddressId(Long addressId);
 
     @EntityGraph(attributePaths = {"orderItems"})
     List<Order> findByMemberIdOrderByOrderedAtDesc(Long memberId);
     
     @Query("""
-    	    SELECT o.memberId, SUM(o.totalAmount)
+    	    SELECT o.member.id, SUM(o.totalAmount)
     	    FROM Order o
     	    WHERE o.orderedAt >= :start
     	      AND o.orderedAt < :end
     	      AND o.status = co.kr.allpick.domain.order.entity.Order.OrderStatus.DELIVERED
-    	    GROUP BY o.memberId
+    	    GROUP BY o.member.id
     	    """)
     	List<Object[]> sumDeliveredAmountByMemberBetween(
     	        @Param("start") LocalDateTime start,

--- a/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
@@ -39,74 +39,76 @@ import lombok.RequiredArgsConstructor;
 public class OrderServiceImpl implements OrderService {
 
     private static final Logger logger = LogManager.getLogger(OrderServiceImpl.class);
-    
+
     private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final PaymentRepository paymentRepository;
     private final DeliveryAddressRepository deliveryAddressRepository;
-
     private final MemberRepository memberRepository;
     private final MemberCouponRepository memberCouponRepository;
 
-    
-    
-    // OrderCreateRequestDto 안에 memberId, addressId, memberCouponId 모두 있음. 
     @Override
     @Transactional
     public OrderResponseDto createOrder(OrderCreateRequestDto request) {
         logger.info("주문 생성 요청 - memberId: {}", request.getMemberId());
 
-        // 1. 사용자 및 배송지 확인
+        // 1. 회원 확인
         Member member = memberRepository.findById(request.getMemberId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
+        // 2. 배송지 확인
         DeliveryAddress deliveryAddress = deliveryAddressRepository.findById(request.getAddressId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
 
-        // 2. 쿠폰 확인 (Optional 활용으로 간결하게 처리)
+        // 3. 쿠폰 확인 (쿠폰 없이 주문 가능)
         MemberCoupon memberCoupon = null;
         if (request.getMemberCouponId() != null) {
             memberCoupon = memberCouponRepository.findById(request.getMemberCouponId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_COUPON_NOT_FOUND));
         }
 
-        // 3. 주문 엔티티 생성 및 초기 저장 (ID와 연관관계를 위해 먼저 생성)
+        // 4. 주문번호 생성
         String orderNumber = generateUniqueOrderNumber();
+
+        // 5. 주문 엔티티 생성 및 저장
         Order order = orderRepository.save(request.toEntity(member, memberCoupon, deliveryAddress, orderNumber));
 
-        // 4. 주문 항목 생성 및 상품 처리
+        // 6. 주문 상품 처리 (재고 검증 → 차감 → OrderItem 생성)
         for (OrderItemRequestDto itemDto : request.getOrderItems()) {
             Product product = productRepository.findById(itemDto.getProductId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
-            // TODO: 재고 차감 로직 (예: product.decreaseStock(itemDto.getQuantity()))
-            
+         // 재고 검증 + 차감을 서비스에서 직접
+            if (product.getOptionList().isEmpty()) {
+                // stock 필드가 없으니 주문 수량만 검증
+                throw new BusinessException(ErrorCode.PRODUCT_OUT_OF_STOCK);
+            }
+
+            // OrderItem 생성 및 저장
             OrderItem orderItem = itemDto.toEntity(product, order);
-            order.addOrderItem(orderItem); // Order 내부 리스트에 추가
+            orderItemRepository.save(orderItem);
+            order.addOrderItem(orderItem);
         }
 
-        // 5. 총 금액 업데이트 (기존 로직 유지)
-        BigDecimal totalAmount = order.getOrderItems().stream()
-                .map(OrderItem::getTotalPrice)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-       
+        // 7. 총 금액 DB에서 집계
+        BigDecimal totalAmount = orderItemRepository.sumTotalPriceByOrderId(order.getOrderId());
         order.updateTotalAmount(totalAmount);
 
-        // 6. 결과 반환 
-        // @Transactional이 걸려있으므로, 별도의 save 호출 없이도 변경 사항(totalAmount)이 DB에 반영됩니다.
+        Order savedOrder = orderRepository.save(order);
+
         logger.info("주문 생성 완료 - orderNumber: {}", orderNumber);
-        return OrderResponseDto.from(order, order.getOrderItems());
+        return OrderResponseDto.from(savedOrder, savedOrder.getOrderItems());
     }
 
     @Override
     @Transactional(readOnly = true)
     public OrderResponseDto getOrder(Long orderId) {
         logger.info("주문 조회 - orderId: {}", orderId);
-        Order order = orderRepository.findById(orderId)
+        // fetch join으로 OrderItem 한 번에 조회
+        Order order = orderRepository.findByIdWithItems(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-        List<OrderItem> orderItems = orderItemRepository.findByOrder_OrderId(orderId);
-        return OrderResponseDto.from(order, orderItems);
+        return OrderResponseDto.from(order, order.getOrderItems());
     }
 
     @Override
@@ -131,6 +133,7 @@ public class OrderServiceImpl implements OrderService {
 
         DeliveryAddressResponseDto saved = DeliveryAddressResponseDto.from(
                 deliveryAddressRepository.save(request.toEntity(memberId)));
+
         logger.info("배송지 추가 완료 - addressId: {}", saved.getAddressId());
         return saved;
     }
@@ -144,7 +147,7 @@ public class OrderServiceImpl implements OrderService {
                 .map(DeliveryAddressResponseDto::from)
                 .toList();
     }
-    
+
     @Override
     @Transactional
     public DeliveryAddressResponseDto updateDeliveryAddress(Long memberId, Long addressId, DeliveryAddressRequestDto request) {
@@ -165,6 +168,7 @@ public class OrderServiceImpl implements OrderService {
         address.delete();
     }
 
+    // 배송지 조회 + 소유권 검증
     private DeliveryAddress findAddressAndValidateOwner(Long memberId, Long addressId) {
         DeliveryAddress address = deliveryAddressRepository.findById(addressId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
@@ -174,13 +178,14 @@ public class OrderServiceImpl implements OrderService {
         return address;
     }
 
+    // 주문에 사용된 배송지 수정/삭제 방지
     private void validateAddressNotUsedInOrder(Long addressId) {
         if (orderRepository.existsByDeliveryAddress_AddressId(addressId)) {
             throw new BusinessException(ErrorCode.ADDRESS_CANNOT_MODIFY);
         }
     }
 
-//    주문 번호 생성
+    // 중복 없는 주문번호 생성
     private String generateUniqueOrderNumber() {
         String orderNumber;
         do {

--- a/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
@@ -184,7 +184,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     private void validateAddressNotUsedInOrder(Long addressId) {
-        if (orderRepository.existsByAddressId(addressId)) {
+        if (orderRepository.existsByDeliveryAddress_AddressId(addressId)) {
             throw new BusinessException(ErrorCode.ADDRESS_CANNOT_MODIFY);
         }
     }

--- a/src/main/java/co/kr/allpick/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/co/kr/allpick/domain/review/repository/ReviewRepository.java
@@ -22,6 +22,7 @@ public interface ReviewRepository extends JpaRepository<Review , Long>{
 	Page<Review> findByProductId(@Param("productId") Long productId, Pageable pageable);
 	
 	// 2. 기존리뷰 작성 내역 확인 
+	@Query("SELECT COUNT(r) > 0 FROM Review r WHERE r.orderItem.orderItemId = :orderItemId")
 	boolean existsByOrderItemId(Long orderItemId);
 	
 	

--- a/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
@@ -19,4 +19,6 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
     boolean existsByMemberId(Long memberId);
 
     Optional<Seller> findByMemberIdAndDeletedAtIsNull(Long memberId);
+    
+    
 }

--- a/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
@@ -19,6 +19,4 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
     boolean existsByMemberId(Long memberId);
 
     Optional<Seller> findByMemberIdAndDeletedAtIsNull(Long memberId);
-    
-    
 }

--- a/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
@@ -19,4 +19,7 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
     boolean existsByMemberId(Long memberId);
 
     Optional<Seller> findByMemberIdAndDeletedAtIsNull(Long memberId);
+    
+    boolean existsByMemberIdAndDeletedAtIsNull(Long memberId);
+
 }

--- a/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
@@ -98,7 +98,7 @@ public class SellerAuthServiceImpl implements SellerAuthService {
         Seller seller = sellerRepository.findByMemberIdAndDeletedAtIsNull(member.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_SELLER));
 
-        if (seller.getStatus() == SellerStatus.SUSPENDED) {
+        if (seller.getStatus() != SellerStatus.APPROVED) {
             throw new BusinessException(ErrorCode.NOT_SELLER);
         }
 

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
     // Product
     PRODUCT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PRODUCT_ALREADY_EXISTS", "이미 존재하는 상품입니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_NOT_FOUND", "존재하지 않는 상품입니다."),
+    PRODUCT_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "PRODUCT_OUT_OF_STOCK", "재고가 부족합니다."),
 
     // ProductOption
     PRODUCT_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND,"PRODUCT_OPTION_NOT_FOUND", "존재하지 않는 상품 옵션입니다."),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,8 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 # JWT
-jwt.secret=mysecretkey1234567890123456789012
-jwt.expiration-time=86400000
+jwt.secret=${JWT_SECRET}
+jwt.expiration-time=${JWT_EXPIRATION_TIME}
 
 # Redis
 # spring.data.redis.host=[Redis EC2 퍼블릭 IP]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,8 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 # JWT
-jwt.secret=${JWT_SECRET}
-jwt.expiration-time=${JWT_EXPIRATION_TIME}
+jwt.secret=mysecretkey1234567890123456789012
+jwt.expiration-time=86400000
 
 # Redis
 # spring.data.redis.host=[Redis EC2 퍼블릭 IP]

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImplTest.java
@@ -21,6 +21,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import co.kr.allpick.domain.seller.entity.Seller;
+import co.kr.allpick.domain.seller.repository.SellerRepository;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -45,6 +49,9 @@ class ClaimServiceImplTest {
     @Mock
     OrderItemRepository orderItemRepository;
 
+    @Mock
+    SellerRepository sellerRepository;
+    
     @InjectMocks
     ClaimServiceImpl claimService;
 
@@ -322,5 +329,50 @@ class ClaimServiceImplTest {
         assertThatThrownBy(() -> claimService.rejectClaim(claimId, request))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.CLAIM_ALREADY_CANCELLED.getMessage());
+    }
+    
+    @Test
+    @DisplayName("클레임 승인 실패 - 판매자가 아닌 회원")
+    void approveClaim_notSeller_throwException() {
+        // given
+        Long claimId = 1L;
+        Long memberId = 1L;
+
+        Claim mockClaim = buildMockClaim();
+
+        given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
+        given(sellerRepository.existsByMemberIdAndDeletedAtIsNull(memberId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> claimService.approveClaim(claimId, memberId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.NOT_SELLER.getMessage());
+    }
+
+    @Test
+    @DisplayName("클레임 승인 성공 - 판매자 본인")
+    void approveClaim_validSeller_success() {
+        // given
+        Long claimId = 1L;
+        Long memberId = 1L;
+        Long orderItemId = 10L;
+
+        Claim mockClaim = buildMockClaim();
+
+        Member mockMember = mock(Member.class);
+        given(mockMember.getId()).willReturn(memberId);
+
+        Seller mockSeller = Seller.builder().member(mockMember).build();
+        OrderItem mockOrderItem = mock(OrderItem.class);
+        Product mockProduct = mock(Product.class);
+        given(mockProduct.getSeller()).willReturn(mockSeller);
+        given(mockOrderItem.getProduct()).willReturn(mockProduct);
+
+        given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
+        given(sellerRepository.existsByMemberIdAndDeletedAtIsNull(memberId)).willReturn(true);
+        given(orderItemRepository.findByIdWithSellerMember(orderItemId)).willReturn(Optional.of(mockOrderItem));
+
+        // when & then
+        claimService.approveClaim(claimId, memberId);
     }
 }


### PR DESCRIPTION
## 개요
- 판매자 클레임 승인/거부 API 구현

---

## 작업 내용
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller: 판매자 클레임 승인(`PATCH /api/claims/{claimId}/approve`), 거부(`PATCH /api/claims/{claimId}/seller-reject`) 엔드포인트 추가
- Service: `approveClaim`, `rejectClaimBySeller` 메서드 구현 / 판매자 소유권 검증 헬퍼(`validateSellerClaimOwnership`), 거부 가능 상태 검증 공통 메서드(`validateRejectableStatus`) 추가
- Repository: `SellerRepository` 의존성 추가 (`ClaimServiceImpl`)
- 기타: `ClaimControllerDocs`에 판매자용 Swagger 문서 추가

---

## 관련 이슈
- 관련 이슈: #이슈번호

---

## 변경 전 / 후

### Before
- 클레임 승인/거부가 관리자 전용으로만 구현되어 있어 판매자가 자신의 상품에 대한 클레임을 직접 처리할 수 없었음

### After
- 판매자가 JWT 토큰으로 인증 후 자신의 상품에 접수된 클레임을 직접 승인(`SUBMITTED → IN_PROGRESS`) 또는 거부 처리 가능
- `Claim → OrderItem → Product → Seller → Member` 경로로 소유권 검증하여 타 판매자 클레임 접근 차단
- 
<img width="1530" height="911" alt="image" src="https://github.com/user-attachments/assets/f13a15c8-3ae6-48ac-8606-8aa86e869596" />


<img width="1534" height="903" alt="image" src="https://github.com/user-attachments/assets/5490c8f9-99be-4672-9cd5-825a1682f4f3" />

