### PR TITLE
feat: 관리자 상품 승인/거절 기능 구현

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/AdminProductApprovalController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/AdminProductApprovalController.java
@@ -1,0 +1,42 @@
+package co.kr.allpick.domain.admin.product.controller;
+
+import co.kr.allpick.domain.admin.product.controller.docs.AdminProductApprovalControllerDocs;
+import co.kr.allpick.domain.admin.product.dto.ProductApprovalResponseDto;
+import co.kr.allpick.domain.admin.product.dto.ProductRejectRequestDto;
+import co.kr.allpick.domain.admin.product.service.AdminProductApprovalService;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/products")
+public class AdminProductApprovalController implements AdminProductApprovalControllerDocs {
+
+    private final AdminProductApprovalService adminProductApprovalService;
+
+    @Override
+    @PatchMapping("/{productId}/approve")
+    public ResponseEntity<ApiResponse<ProductApprovalResponseDto>> approveProduct(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("productId") Long productId) {
+        return ApiResponse.success("상품 승인 성공", adminProductApprovalService.approveProduct(adminInfo, productId));
+    }
+
+    @Override
+    @PatchMapping("/{productId}/reject")
+    public ResponseEntity<ApiResponse<ProductApprovalResponseDto>> rejectProduct(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("productId") Long productId,
+            @RequestBody @Valid ProductRejectRequestDto request) {
+        return ApiResponse.success("상품 승인 거절 성공", adminProductApprovalService.rejectProduct(adminInfo, productId, request));
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/AdminProductApprovalControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/AdminProductApprovalControllerDocs.java
@@ -1,0 +1,42 @@
+package co.kr.allpick.domain.admin.product.controller.docs;
+
+import co.kr.allpick.domain.admin.product.dto.ProductApprovalResponseDto;
+import co.kr.allpick.domain.admin.product.dto.ProductRejectRequestDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Admin Product Approval", description = "관리자 상품 승인 API")
+public interface AdminProductApprovalControllerDocs {
+
+    @Operation(summary = "상품 승인", description = "SUPER_ADMIN이 PENDING 상태의 상품을 승인합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상품 승인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "승인 가능한 상태가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "SUPER_ADMIN 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "상품 없음")
+    })
+    ResponseEntity<ApiResponse<ProductApprovalResponseDto>> approveProduct(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @Parameter(description = "상품 ID") @PathVariable("productId") Long productId);
+
+    @Operation(summary = "상품 승인 거절", description = "SUPER_ADMIN이 PENDING 상태의 상품을 거절합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상품 거절 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "거절 가능한 상태가 아니거나 거절 사유 누락"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "SUPER_ADMIN 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "상품 없음")
+    })
+    ResponseEntity<ApiResponse<ProductApprovalResponseDto>> rejectProduct(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @Parameter(description = "상품 ID") @PathVariable("productId") Long productId,
+            @RequestBody @Valid ProductRejectRequestDto request);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/ProductApprovalResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/ProductApprovalResponseDto.java
@@ -1,0 +1,47 @@
+package co.kr.allpick.domain.admin.product.dto;
+
+import co.kr.allpick.domain.admin.product.entity.ProductApproval;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "상품 승인 처리 응답 DTO")
+public class ProductApprovalResponseDto {
+
+    @Schema(description = "상품 승인 이력 ID", example = "1")
+    private Long productApprovalId;
+
+    @Schema(description = "상품 ID", example = "1")
+    private Long productId;
+
+    @Schema(description = "처리 관리자 ID", example = "1")
+    private Long adminId;
+
+    @Schema(description = "요청 유형", example = "REGISTER")
+    private ProductApproval.RequestType requestType;
+
+    @Schema(description = "승인 처리 상태", example = "APPROVED")
+    private ProductApproval.ApprovalStatus status;
+
+    @Schema(description = "거절 사유", example = "상품 설명 보완이 필요합니다.")
+    private String rejectReason;
+
+    @Schema(description = "처리 일시")
+    private LocalDateTime processedAt;
+
+    public static ProductApprovalResponseDto from(ProductApproval productApproval) {
+        return ProductApprovalResponseDto.builder()
+                .productApprovalId(productApproval.getProductApprovalId())
+                .productId(productApproval.getProduct().getProductId())
+                .adminId(productApproval.getAdmin().getAdminId())
+                .requestType(productApproval.getRequestType())
+                .status(productApproval.getStatus())
+                .rejectReason(productApproval.getRejectReason())
+                .processedAt(productApproval.getProcessedAt())
+                .build();
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/ProductRejectRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/ProductRejectRequestDto.java
@@ -1,0 +1,18 @@
+package co.kr.allpick.domain.admin.product.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "상품 승인 거절 요청 DTO")
+public class ProductRejectRequestDto {
+
+    @NotBlank
+    @Schema(description = "거절 사유", example = "상품 설명 보완이 필요합니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String rejectReason;
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/entity/ProductApproval.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/entity/ProductApproval.java
@@ -1,0 +1,96 @@
+package co.kr.allpick.domain.admin.product.entity;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.product.entity.Product;
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "product_approvals")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductApproval extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_approval_id")
+    private Long productApprovalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
+    private Admin admin;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "request_type", nullable = false, length = 20)
+    private RequestType requestType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ApprovalStatus status;
+
+    @Column(name = "reject_reason", columnDefinition = "TEXT")
+    private String rejectReason;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Builder
+    private ProductApproval(Product product, Admin admin, RequestType requestType,
+                            ApprovalStatus status, String rejectReason, LocalDateTime processedAt) {
+        this.product = product;
+        this.admin = admin;
+        this.requestType = requestType;
+        this.status = status;
+        this.rejectReason = rejectReason;
+        this.processedAt = processedAt;
+    }
+
+    public static ProductApproval approved(Product product, Admin admin, RequestType requestType) {
+        return ProductApproval.builder()
+                .product(product)
+                .admin(admin)
+                .requestType(requestType)
+                .status(ApprovalStatus.APPROVED)
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static ProductApproval rejected(Product product, Admin admin, RequestType requestType, String rejectReason) {
+        return ProductApproval.builder()
+                .product(product)
+                .admin(admin)
+                .requestType(requestType)
+                .status(ApprovalStatus.REJECTED)
+                .rejectReason(rejectReason)
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public enum RequestType {
+        REGISTER, UPDATE, DELETE
+    }
+
+    public enum ApprovalStatus {
+        PENDING, APPROVED, REJECTED
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/repository/ProductApprovalRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/repository/ProductApprovalRepository.java
@@ -1,0 +1,7 @@
+package co.kr.allpick.domain.admin.product.repository;
+
+import co.kr.allpick.domain.admin.product.entity.ProductApproval;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductApprovalRepository extends JpaRepository<ProductApproval, Long> {
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/AdminProductApprovalService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/AdminProductApprovalService.java
@@ -1,0 +1,12 @@
+package co.kr.allpick.domain.admin.product.service;
+
+import co.kr.allpick.domain.admin.product.dto.ProductApprovalResponseDto;
+import co.kr.allpick.domain.admin.product.dto.ProductRejectRequestDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+
+public interface AdminProductApprovalService {
+
+    ProductApprovalResponseDto approveProduct(AdminJwtUserInfoDto adminInfo, Long productId);
+
+    ProductApprovalResponseDto rejectProduct(AdminJwtUserInfoDto adminInfo, Long productId, ProductRejectRequestDto request);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImpl.java
@@ -78,14 +78,14 @@ public class AdminProductApprovalServiceImpl implements AdminProductApprovalServ
         Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
         if (product.getApprovalStatus() != Product.ApprovalStatus.PENDING) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.APPROVAL_ALREADY_PROCESSED);
         }
         return product;
     }
 
     private void validateRejectReason(String rejectReason) {
         if (!StringUtils.hasText(rejectReason)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.REJECT_REASON_REQUIRED);
         }
     }
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImpl.java
@@ -1,0 +1,83 @@
+package co.kr.allpick.domain.admin.product.service.impl;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.admin.product.dto.ProductApprovalResponseDto;
+import co.kr.allpick.domain.admin.product.dto.ProductRejectRequestDto;
+import co.kr.allpick.domain.admin.product.entity.ProductApproval;
+import co.kr.allpick.domain.admin.product.repository.ProductApprovalRepository;
+import co.kr.allpick.domain.admin.product.service.AdminProductApprovalService;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.domain.product.entity.Product;
+import co.kr.allpick.domain.product.repository.ProductRepository;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AdminProductApprovalServiceImpl implements AdminProductApprovalService {
+
+    private final ProductRepository productRepository;
+    private final AdminRepository adminRepository;
+    private final ProductApprovalRepository productApprovalRepository;
+
+    @Override
+    @Transactional
+    public ProductApprovalResponseDto approveProduct(AdminJwtUserInfoDto adminInfo, Long productId) {
+        Admin admin = getSuperAdmin(adminInfo);
+        Product product = getPendingProduct(productId);
+
+        product.approve();
+        ProductApproval productApproval = productApprovalRepository.save(
+                ProductApproval.approved(product, admin, ProductApproval.RequestType.REGISTER)
+        );
+
+        return ProductApprovalResponseDto.from(productApproval);
+    }
+
+    @Override
+    @Transactional
+    public ProductApprovalResponseDto rejectProduct(AdminJwtUserInfoDto adminInfo, Long productId, ProductRejectRequestDto request) {
+        Admin admin = getSuperAdmin(adminInfo);
+        Product product = getPendingProduct(productId);
+        validateRejectReason(request.getRejectReason());
+
+        product.reject();
+        ProductApproval productApproval = productApprovalRepository.save(
+                ProductApproval.rejected(product, admin, ProductApproval.RequestType.REGISTER, request.getRejectReason())
+        );
+
+        return ProductApprovalResponseDto.from(productApproval);
+    }
+
+    private Admin getSuperAdmin(AdminJwtUserInfoDto adminInfo) {
+        if (adminInfo == null || adminInfo.getRole() != Admin.AdminRole.SUPER_ADMIN) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+        Admin admin = adminRepository.findById(adminInfo.getAdminId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+        if (admin.getRole() != Admin.AdminRole.SUPER_ADMIN || admin.getStatus() != Admin.AdminStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+        return admin;
+    }
+
+    private Product getPendingProduct(Long productId) {
+        Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+        if (product.getApprovalStatus() != Product.ApprovalStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        return product;
+    }
+
+    private void validateRejectReason(String rejectReason) {
+        if (!StringUtils.hasText(rejectReason)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImpl.java
@@ -13,6 +13,8 @@ import co.kr.allpick.global.config.AdminJwtUserInfoDto;
 import co.kr.allpick.global.exception.BusinessException;
 import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -20,6 +22,8 @@ import org.springframework.util.StringUtils;
 @Service
 @RequiredArgsConstructor
 public class AdminProductApprovalServiceImpl implements AdminProductApprovalService {
+
+    private static final Logger logger = LogManager.getLogger(AdminProductApprovalServiceImpl.class);
 
     private final ProductRepository productRepository;
     private final AdminRepository adminRepository;
@@ -36,6 +40,8 @@ public class AdminProductApprovalServiceImpl implements AdminProductApprovalServ
                 ProductApproval.approved(product, admin, ProductApproval.RequestType.REGISTER)
         );
 
+        logger.info("[AdminProductApprovalServiceImpl] 상품 승인 완료 - actorAdminId: {}, productId: {}",
+                admin.getAdminId(), productId);
         return ProductApprovalResponseDto.from(productApproval);
     }
 
@@ -51,6 +57,8 @@ public class AdminProductApprovalServiceImpl implements AdminProductApprovalServ
                 ProductApproval.rejected(product, admin, ProductApproval.RequestType.REGISTER, request.getRejectReason())
         );
 
+        logger.info("[AdminProductApprovalServiceImpl] 상품 승인 거절 완료 - actorAdminId: {}, productId: {}",
+                admin.getAdminId(), productId);
         return ProductApprovalResponseDto.from(productApproval);
     }
 

--- a/src/main/java/co/kr/allpick/domain/admin/seller/controller/AdminSellerApprovalController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/controller/AdminSellerApprovalController.java
@@ -1,0 +1,42 @@
+package co.kr.allpick.domain.admin.seller.controller;
+
+import co.kr.allpick.domain.admin.seller.controller.docs.AdminSellerApprovalControllerDocs;
+import co.kr.allpick.domain.admin.seller.dto.SellerApprovalResponseDto;
+import co.kr.allpick.domain.admin.seller.dto.SellerRejectRequestDto;
+import co.kr.allpick.domain.admin.seller.service.AdminSellerApprovalService;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/sellers")
+public class AdminSellerApprovalController implements AdminSellerApprovalControllerDocs {
+
+    private final AdminSellerApprovalService adminSellerApprovalService;
+
+    @Override
+    @PatchMapping("/{sellerId}/approve")
+    public ResponseEntity<ApiResponse<SellerApprovalResponseDto>> approveSeller(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("sellerId") Long sellerId) {
+        return ApiResponse.success("판매자 승인 성공", adminSellerApprovalService.approveSeller(adminInfo, sellerId));
+    }
+
+    @Override
+    @PatchMapping("/{sellerId}/reject")
+    public ResponseEntity<ApiResponse<SellerApprovalResponseDto>> rejectSeller(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("sellerId") Long sellerId,
+            @RequestBody @Valid SellerRejectRequestDto request) {
+        return ApiResponse.success("판매자 승인 거절 성공", adminSellerApprovalService.rejectSeller(adminInfo, sellerId, request));
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/controller/docs/AdminSellerApprovalControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/controller/docs/AdminSellerApprovalControllerDocs.java
@@ -1,0 +1,42 @@
+package co.kr.allpick.domain.admin.seller.controller.docs;
+
+import co.kr.allpick.domain.admin.seller.dto.SellerApprovalResponseDto;
+import co.kr.allpick.domain.admin.seller.dto.SellerRejectRequestDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Admin Seller Approval", description = "관리자 판매자 승인 API")
+public interface AdminSellerApprovalControllerDocs {
+
+    @Operation(summary = "판매자 승인", description = "SUPER_ADMIN이 PENDING 상태의 판매자를 승인합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "판매자 승인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "승인 가능한 상태가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "SUPER_ADMIN 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "판매자 없음")
+    })
+    ResponseEntity<ApiResponse<SellerApprovalResponseDto>> approveSeller(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @Parameter(description = "판매자 ID") @PathVariable("sellerId") Long sellerId);
+
+    @Operation(summary = "판매자 승인 거절", description = "SUPER_ADMIN이 PENDING 상태의 판매자를 거절합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "판매자 거절 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "거절 가능한 상태가 아니거나 거절 사유 누락"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "SUPER_ADMIN 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "판매자 없음")
+    })
+    ResponseEntity<ApiResponse<SellerApprovalResponseDto>> rejectSeller(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @Parameter(description = "판매자 ID") @PathVariable("sellerId") Long sellerId,
+            @RequestBody @Valid SellerRejectRequestDto request);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/dto/SellerApprovalResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/dto/SellerApprovalResponseDto.java
@@ -1,0 +1,47 @@
+package co.kr.allpick.domain.admin.seller.dto;
+
+import co.kr.allpick.domain.admin.seller.entity.SellerApproval;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "판매자 승인 처리 응답 DTO")
+public class SellerApprovalResponseDto {
+
+    @Schema(description = "판매자 승인 이력 ID", example = "1")
+    private Long sellerApprovalId;
+
+    @Schema(description = "판매자 ID", example = "1")
+    private Long sellerId;
+
+    @Schema(description = "처리 관리자 ID", example = "1")
+    private Long adminId;
+
+    @Schema(description = "요청 유형", example = "REGISTER")
+    private SellerApproval.RequestType requestType;
+
+    @Schema(description = "승인 처리 상태", example = "APPROVED")
+    private SellerApproval.ApprovalStatus status;
+
+    @Schema(description = "거절 사유", example = "사업자등록번호 확인이 필요합니다.")
+    private String rejectReason;
+
+    @Schema(description = "처리 일시")
+    private LocalDateTime processedAt;
+
+    public static SellerApprovalResponseDto from(SellerApproval sellerApproval) {
+        return SellerApprovalResponseDto.builder()
+                .sellerApprovalId(sellerApproval.getSellerApprovalId())
+                .sellerId(sellerApproval.getSeller().getSellerId())
+                .adminId(sellerApproval.getAdmin().getAdminId())
+                .requestType(sellerApproval.getRequestType())
+                .status(sellerApproval.getStatus())
+                .rejectReason(sellerApproval.getRejectReason())
+                .processedAt(sellerApproval.getProcessedAt())
+                .build();
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/dto/SellerRejectRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/dto/SellerRejectRequestDto.java
@@ -1,0 +1,18 @@
+package co.kr.allpick.domain.admin.seller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "판매자 승인 거절 요청 DTO")
+public class SellerRejectRequestDto {
+
+    @NotBlank
+    @Schema(description = "거절 사유", example = "사업자등록번호 확인이 필요합니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String rejectReason;
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/entity/SellerApproval.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/entity/SellerApproval.java
@@ -87,7 +87,7 @@ public class SellerApproval extends BaseEntity {
     }
 
     public enum RequestType {
-        REGISTER, SUSPEND
+        REGISTER
     }
 
     public enum ApprovalStatus {

--- a/src/main/java/co/kr/allpick/domain/admin/seller/entity/SellerApproval.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/entity/SellerApproval.java
@@ -1,0 +1,96 @@
+package co.kr.allpick.domain.admin.seller.entity;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.seller.entity.Seller;
+import co.kr.allpick.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "seller_approvals")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SellerApproval extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seller_approval_id")
+    private Long sellerApprovalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id", nullable = false)
+    private Seller seller;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
+    private Admin admin;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "request_type", nullable = false, length = 20)
+    private RequestType requestType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ApprovalStatus status;
+
+    @Column(name = "reject_reason", columnDefinition = "TEXT")
+    private String rejectReason;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Builder
+    private SellerApproval(Seller seller, Admin admin, RequestType requestType,
+                           ApprovalStatus status, String rejectReason, LocalDateTime processedAt) {
+        this.seller = seller;
+        this.admin = admin;
+        this.requestType = requestType;
+        this.status = status;
+        this.rejectReason = rejectReason;
+        this.processedAt = processedAt;
+    }
+
+    public static SellerApproval approved(Seller seller, Admin admin, RequestType requestType) {
+        return SellerApproval.builder()
+                .seller(seller)
+                .admin(admin)
+                .requestType(requestType)
+                .status(ApprovalStatus.APPROVED)
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static SellerApproval rejected(Seller seller, Admin admin, RequestType requestType, String rejectReason) {
+        return SellerApproval.builder()
+                .seller(seller)
+                .admin(admin)
+                .requestType(requestType)
+                .status(ApprovalStatus.REJECTED)
+                .rejectReason(rejectReason)
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public enum RequestType {
+        REGISTER, SUSPEND
+    }
+
+    public enum ApprovalStatus {
+        PENDING, APPROVED, REJECTED
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/repository/SellerApprovalRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/repository/SellerApprovalRepository.java
@@ -1,0 +1,7 @@
+package co.kr.allpick.domain.admin.seller.repository;
+
+import co.kr.allpick.domain.admin.seller.entity.SellerApproval;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerApprovalRepository extends JpaRepository<SellerApproval, Long> {
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/service/AdminSellerApprovalService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/service/AdminSellerApprovalService.java
@@ -1,0 +1,12 @@
+package co.kr.allpick.domain.admin.seller.service;
+
+import co.kr.allpick.domain.admin.seller.dto.SellerApprovalResponseDto;
+import co.kr.allpick.domain.admin.seller.dto.SellerRejectRequestDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+
+public interface AdminSellerApprovalService {
+
+    SellerApprovalResponseDto approveSeller(AdminJwtUserInfoDto adminInfo, Long sellerId);
+
+    SellerApprovalResponseDto rejectSeller(AdminJwtUserInfoDto adminInfo, Long sellerId, SellerRejectRequestDto request);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
@@ -79,14 +79,14 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
         Seller seller = sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
         if (seller.getStatus() != SellerStatus.PENDING) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.APPROVAL_ALREADY_PROCESSED);
         }
         return seller;
     }
 
     private void validateRejectReason(String rejectReason) {
         if (!StringUtils.hasText(rejectReason)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.REJECT_REASON_REQUIRED);
         }
     }
 }

--- a/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
@@ -1,0 +1,84 @@
+package co.kr.allpick.domain.admin.seller.service.impl;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.domain.admin.seller.dto.SellerApprovalResponseDto;
+import co.kr.allpick.domain.admin.seller.dto.SellerRejectRequestDto;
+import co.kr.allpick.domain.admin.seller.entity.SellerApproval;
+import co.kr.allpick.domain.admin.seller.repository.SellerApprovalRepository;
+import co.kr.allpick.domain.admin.seller.service.AdminSellerApprovalService;
+import co.kr.allpick.domain.seller.entity.Seller;
+import co.kr.allpick.domain.seller.entity.SellerStatus;
+import co.kr.allpick.domain.seller.repository.SellerRepository;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalService {
+
+    private final SellerRepository sellerRepository;
+    private final AdminRepository adminRepository;
+    private final SellerApprovalRepository sellerApprovalRepository;
+
+    @Override
+    @Transactional
+    public SellerApprovalResponseDto approveSeller(AdminJwtUserInfoDto adminInfo, Long sellerId) {
+        Admin admin = getSuperAdmin(adminInfo);
+        Seller seller = getPendingSeller(sellerId);
+
+        seller.approve();
+        SellerApproval sellerApproval = sellerApprovalRepository.save(
+                SellerApproval.approved(seller, admin, SellerApproval.RequestType.REGISTER)
+        );
+
+        return SellerApprovalResponseDto.from(sellerApproval);
+    }
+
+    @Override
+    @Transactional
+    public SellerApprovalResponseDto rejectSeller(AdminJwtUserInfoDto adminInfo, Long sellerId, SellerRejectRequestDto request) {
+        Admin admin = getSuperAdmin(adminInfo);
+        Seller seller = getPendingSeller(sellerId);
+        validateRejectReason(request.getRejectReason());
+
+        seller.reject();
+        SellerApproval sellerApproval = sellerApprovalRepository.save(
+                SellerApproval.rejected(seller, admin, SellerApproval.RequestType.REGISTER, request.getRejectReason())
+        );
+
+        return SellerApprovalResponseDto.from(sellerApproval);
+    }
+
+    private Admin getSuperAdmin(AdminJwtUserInfoDto adminInfo) {
+        if (adminInfo == null || adminInfo.getRole() != Admin.AdminRole.SUPER_ADMIN) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+        Admin admin = adminRepository.findById(adminInfo.getAdminId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+        if (admin.getRole() != Admin.AdminRole.SUPER_ADMIN || admin.getStatus() != Admin.AdminStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+        return admin;
+    }
+
+    private Seller getPendingSeller(Long sellerId) {
+        Seller seller = sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+        if (seller.getStatus() != SellerStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        return seller;
+    }
+
+    private void validateRejectReason(String rejectReason) {
+        if (!StringUtils.hasText(rejectReason)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
@@ -14,6 +14,8 @@ import co.kr.allpick.global.config.AdminJwtUserInfoDto;
 import co.kr.allpick.global.exception.BusinessException;
 import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -21,6 +23,8 @@ import org.springframework.util.StringUtils;
 @Service
 @RequiredArgsConstructor
 public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalService {
+
+    private static final Logger logger = LogManager.getLogger(AdminSellerApprovalServiceImpl.class);
 
     private final SellerRepository sellerRepository;
     private final AdminRepository adminRepository;
@@ -37,6 +41,8 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
                 SellerApproval.approved(seller, admin, SellerApproval.RequestType.REGISTER)
         );
 
+        logger.info("[AdminSellerApprovalServiceImpl] 판매자 승인 완료 - actorAdminId: {}, sellerId: {}",
+                admin.getAdminId(), sellerId);
         return SellerApprovalResponseDto.from(sellerApproval);
     }
 
@@ -52,6 +58,8 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
                 SellerApproval.rejected(seller, admin, SellerApproval.RequestType.REGISTER, request.getRejectReason())
         );
 
+        logger.info("[AdminSellerApprovalServiceImpl] 판매자 승인 거절 완료 - actorAdminId: {}, sellerId: {}",
+                admin.getAdminId(), sellerId);
         return SellerApprovalResponseDto.from(sellerApproval);
     }
 

--- a/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
@@ -18,8 +18,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
-
 @Service
 @RequiredArgsConstructor
 public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalService {
@@ -51,7 +49,6 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
     public SellerApprovalResponseDto rejectSeller(AdminJwtUserInfoDto adminInfo, Long sellerId, SellerRejectRequestDto request) {
         Admin admin = getSuperAdmin(adminInfo);
         Seller seller = getPendingSeller(sellerId);
-        validateRejectReason(request.getRejectReason());
 
         seller.reject();
         SellerApproval sellerApproval = sellerApprovalRepository.save(
@@ -79,14 +76,9 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
         Seller seller = sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
         if (seller.getStatus() != SellerStatus.PENDING) {
-            throw new BusinessException(ErrorCode.APPROVAL_ALREADY_PROCESSED);
+            throw new BusinessException(ErrorCode.APPROVAL_NOT_PENDING);
         }
         return seller;
     }
 
-    private void validateRejectReason(String rejectReason) {
-        if (!StringUtils.hasText(rejectReason)) {
-            throw new BusinessException(ErrorCode.REJECT_REASON_REQUIRED);
-        }
-    }
 }

--- a/src/main/java/co/kr/allpick/domain/product/entity/Product.java
+++ b/src/main/java/co/kr/allpick/domain/product/entity/Product.java
@@ -99,12 +99,20 @@ public class Product extends BaseEntity {
     @Column(name = "approval_status", nullable = false)
     private ApprovalStatus approvalStatus = ApprovalStatus.PENDING;
 
+    public void approve() {
+        this.approvalStatus = ApprovalStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.approvalStatus = ApprovalStatus.REJECTED;
+    }
+
     public enum Status {
         ON_SALE, SOLD_OUT, HIDDEN
     }
 
     public enum ApprovalStatus {
-        PENDING, APPROVED, SUSPENDED
+        PENDING, APPROVED, REJECTED, SUSPENDED
 
     }
 }

--- a/src/main/java/co/kr/allpick/domain/product/repository/ProductRepository.java
+++ b/src/main/java/co/kr/allpick/domain/product/repository/ProductRepository.java
@@ -27,6 +27,8 @@ public interface ProductRepository extends JpaRepository<Product, Long>{
 	// 상품명 존재 여부 확인 메서드
 	boolean existsByProductName(String productName);
 
+	Optional<Product> findByProductIdAndDeletedAtIsNull(Long productId);
+
 
 	
 

--- a/src/main/java/co/kr/allpick/domain/seller/entity/Seller.java
+++ b/src/main/java/co/kr/allpick/domain/seller/entity/Seller.java
@@ -46,14 +46,6 @@ public class Seller extends BaseEntity {
     @Builder.Default
     private SellerStatus status = SellerStatus.PENDING;
 
-
-    /**
-     * 판매자 승인 상태 변경 메서드
-     */
-    public void updateStatus(SellerStatus status) {
-        this.status = status;
-    }
-
     public void approve() {
         this.status = SellerStatus.APPROVED;
     }

--- a/src/main/java/co/kr/allpick/domain/seller/entity/Seller.java
+++ b/src/main/java/co/kr/allpick/domain/seller/entity/Seller.java
@@ -54,6 +54,18 @@ public class Seller extends BaseEntity {
         this.status = status;
     }
 
+    public void approve() {
+        this.status = SellerStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = SellerStatus.REJECTED;
+    }
+
+    public void suspend() {
+        this.status = SellerStatus.SUSPENDED;
+    }
+
     /**
      * 은행 정보 업데이트 메서드
      */
@@ -64,7 +76,7 @@ public class Seller extends BaseEntity {
         this.bankAccount = bankAccount;
     }
     public void delete() {
-        this.status = SellerStatus.SUSPENDED;
+        suspend();
         super.delete();
     }
 

--- a/src/main/java/co/kr/allpick/domain/seller/entity/Seller.java
+++ b/src/main/java/co/kr/allpick/domain/seller/entity/Seller.java
@@ -58,9 +58,6 @@ public class Seller extends BaseEntity {
         this.status = SellerStatus.SUSPENDED;
     }
 
-    /**
-     * 은행 정보 업데이트 메서드
-     */
     public void updateInfo(String businessName, String representativeName, String bankName, String bankAccount) {
         this.businessName = businessName;
         this.representativeName = representativeName;

--- a/src/main/java/co/kr/allpick/domain/seller/entity/SellerStatus.java
+++ b/src/main/java/co/kr/allpick/domain/seller/entity/SellerStatus.java
@@ -3,5 +3,6 @@ package co.kr.allpick.domain.seller.entity;
 public enum SellerStatus {
     PENDING,    // 대기
     APPROVED,   // 승인
+    REJECTED,   // 거절
     SUSPENDED   // 정지
 }

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -9,8 +9,7 @@ import lombok.Getter;
 public enum ErrorCode {
 
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 입력값입니다."),
-    APPROVAL_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "APPROVAL_ALREADY_PROCESSED", "이미 처리된 승인 요청입니다."),
-    REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "REJECT_REASON_REQUIRED", "거절 사유는 필수입니다."),
+    APPROVAL_NOT_PENDING(HttpStatus.BAD_REQUEST, "APPROVAL_NOT_PENDING", "승인 대기 상태의 항목만 처리할 수 있습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "주문을 찾을 수 없습니다."),
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_ITEM_NOT_FOUND", "주문 상품을 찾을 수 없습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "결제 정보를 찾을 수 없습니다."),

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 public enum ErrorCode {
 
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 입력값입니다."),
+    APPROVAL_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "APPROVAL_ALREADY_PROCESSED", "이미 처리된 승인 요청입니다."),
+    REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "REJECT_REASON_REQUIRED", "거절 사유는 필수입니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "주문을 찾을 수 없습니다."),
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_ITEM_NOT_FOUND", "주문 상품을 찾을 수 없습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "결제 정보를 찾을 수 없습니다."),

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
@@ -25,9 +25,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AdminProductApprovalServiceImplTest {
@@ -52,10 +52,10 @@ class AdminProductApprovalServiceImplTest {
         Admin admin = superAdmin();
         Product product = product(Product.ApprovalStatus.PENDING);
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
-        when(productRepository.findByProductIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(product));
-        when(productApprovalRepository.save(any(ProductApproval.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(product));
+        given(productApprovalRepository.save(any(ProductApproval.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         ProductApprovalResponseDto result = adminProductApprovalService.approveProduct(adminInfo, 1L);
@@ -82,10 +82,10 @@ class AdminProductApprovalServiceImplTest {
         Product product = product(Product.ApprovalStatus.PENDING);
         ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
-        when(productRepository.findByProductIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(product));
-        when(productApprovalRepository.save(any(ProductApproval.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(product));
+        given(productApprovalRepository.save(any(ProductApproval.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         ProductApprovalResponseDto result = adminProductApprovalService.rejectProduct(adminInfo, 1L, request);
@@ -113,7 +113,7 @@ class AdminProductApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
         verify(productRepository, never()).findByProductIdAndDeletedAtIsNull(any());
         verify(productApprovalRepository, never()).save(any());
     }
@@ -132,12 +132,12 @@ class AdminProductApprovalServiceImplTest {
                 .status(Admin.AdminStatus.ACTIVE)
                 .build();
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
 
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
         verify(productRepository, never()).findByProductIdAndDeletedAtIsNull(any());
         verify(productApprovalRepository, never()).save(any());
     }
@@ -147,13 +147,13 @@ class AdminProductApprovalServiceImplTest {
     void 상품_승인_실패_상품없음() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
-        when(productRepository.findByProductIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 999L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PRODUCT_NOT_FOUND);
         verify(productApprovalRepository, never()).save(any());
     }
 
@@ -162,14 +162,92 @@ class AdminProductApprovalServiceImplTest {
     void 상품_승인_실패_상태전이불가() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
-        when(productRepository.findByProductIdAndDeletedAtIsNull(1L))
-                .thenReturn(Optional.of(product(Product.ApprovalStatus.APPROVED)));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(product(Product.ApprovalStatus.APPROVED)));
 
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - SUPER_ADMIN 권한 없음")
+    void 상품_승인_거절_실패_권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.CS_ADMIN)
+                .build();
+        ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(productRepository, never()).findByProductIdAndDeletedAtIsNull(any());
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - DB 기준 관리자 권한 없음")
+    void 상품_승인_거절_실패_DB관리자권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.CS_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+        ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(productRepository, never()).findByProductIdAndDeletedAtIsNull(any());
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - 상품 없음")
+    void 상품_승인_거절_실패_상품없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 999L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PRODUCT_NOT_FOUND);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - PENDING 상태가 아님")
+    void 상품_승인_거절_실패_상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(product(Product.ApprovalStatus.APPROVED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
         verify(productApprovalRepository, never()).save(any());
     }
 
@@ -181,13 +259,13 @@ class AdminProductApprovalServiceImplTest {
         Product product = product(Product.ApprovalStatus.PENDING);
         ProductRejectRequestDto request = new ProductRejectRequestDto(" ");
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
-        when(productRepository.findByProductIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(product));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(product));
 
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
         assertThat(product.getApprovalStatus()).isEqualTo(Product.ApprovalStatus.PENDING);
         verify(productApprovalRepository, never()).save(any());
     }

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
@@ -1,0 +1,228 @@
+package co.kr.allpick.domain.admin.product.service.impl;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.admin.product.dto.ProductApprovalResponseDto;
+import co.kr.allpick.domain.admin.product.dto.ProductRejectRequestDto;
+import co.kr.allpick.domain.admin.product.entity.ProductApproval;
+import co.kr.allpick.domain.admin.product.repository.ProductApprovalRepository;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.domain.product.entity.Product;
+import co.kr.allpick.domain.product.repository.ProductRepository;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminProductApprovalServiceImplTest {
+
+    @Mock
+    ProductRepository productRepository;
+
+    @Mock
+    AdminRepository adminRepository;
+
+    @Mock
+    ProductApprovalRepository productApprovalRepository;
+
+    @InjectMocks
+    AdminProductApprovalServiceImpl adminProductApprovalService;
+
+    @Test
+    @DisplayName("상품 승인 성공")
+    void 상품_승인_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = superAdmin();
+        Product product = product(Product.ApprovalStatus.PENDING);
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+        when(productRepository.findByProductIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(product));
+        when(productApprovalRepository.save(any(ProductApproval.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ProductApprovalResponseDto result = adminProductApprovalService.approveProduct(adminInfo, 1L);
+
+        // then
+        assertThat(product.getApprovalStatus()).isEqualTo(Product.ApprovalStatus.APPROVED);
+        assertThat(result.getStatus()).isEqualTo(ProductApproval.ApprovalStatus.APPROVED);
+        assertThat(result.getRequestType()).isEqualTo(ProductApproval.RequestType.REGISTER);
+
+        ArgumentCaptor<ProductApproval> captor = ArgumentCaptor.forClass(ProductApproval.class);
+        verify(productApprovalRepository).save(captor.capture());
+        assertThat(captor.getValue().getProduct()).isEqualTo(product);
+        assertThat(captor.getValue().getAdmin()).isEqualTo(admin);
+        assertThat(captor.getValue().getRejectReason()).isNull();
+        assertThat(captor.getValue().getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 성공")
+    void 상품_승인_거절_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = superAdmin();
+        Product product = product(Product.ApprovalStatus.PENDING);
+        ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+        when(productRepository.findByProductIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(product));
+        when(productApprovalRepository.save(any(ProductApproval.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ProductApprovalResponseDto result = adminProductApprovalService.rejectProduct(adminInfo, 1L, request);
+
+        // then
+        assertThat(product.getApprovalStatus()).isEqualTo(Product.ApprovalStatus.REJECTED);
+        assertThat(result.getStatus()).isEqualTo(ProductApproval.ApprovalStatus.REJECTED);
+        assertThat(result.getRejectReason()).isEqualTo("상품 설명 보완 필요");
+
+        ArgumentCaptor<ProductApproval> captor = ArgumentCaptor.forClass(ProductApproval.class);
+        verify(productApprovalRepository).save(captor.capture());
+        assertThat(captor.getValue().getRejectReason()).isEqualTo("상품 설명 보완 필요");
+        assertThat(captor.getValue().getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("상품 승인 실패 - SUPER_ADMIN 권한 없음")
+    void 상품_승인_실패_권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.CS_ADMIN)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+        verify(productRepository, never()).findByProductIdAndDeletedAtIsNull(any());
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 실패 - DB 기준 관리자 권한 없음")
+    void 상품_승인_실패_DB관리자권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.CS_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+        verify(productRepository, never()).findByProductIdAndDeletedAtIsNull(any());
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 실패 - 상품 없음")
+    void 상품_승인_실패_상품없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
+        when(productRepository.findByProductIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 실패 - PENDING 상태가 아님")
+    void 상품_승인_실패_상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
+        when(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .thenReturn(Optional.of(product(Product.ApprovalStatus.APPROVED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - 거절 사유 없음")
+    void 상품_승인_거절_실패_거절사유없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Product product = product(Product.ApprovalStatus.PENDING);
+        ProductRejectRequestDto request = new ProductRejectRequestDto(" ");
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
+        when(productRepository.findByProductIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(product));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+        assertThat(product.getApprovalStatus()).isEqualTo(Product.ApprovalStatus.PENDING);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    private AdminJwtUserInfoDto superAdminInfo() {
+        return AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .build();
+    }
+
+    private Admin superAdmin() {
+        return Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+    }
+
+    private Product product(Product.ApprovalStatus approvalStatus) {
+        return Product.builder()
+                .productId(1L)
+                .productName("테스트 상품")
+                .brand("브랜드")
+                .thumbnailUrl("https://example.com/image.jpg")
+                .description("상품 설명")
+                .price(BigDecimal.valueOf(10000))
+                .manufacturer("제조사")
+                .origin("대한민국")
+                .precaution("주의사항")
+                .status(Product.Status.ON_SALE)
+                .approvalStatus(approvalStatus)
+                .build();
+    }
+}

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
@@ -123,14 +123,7 @@ class AdminProductApprovalServiceImplTest {
     void 상품_승인_실패_DB관리자권한없음() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        Admin admin = Admin.builder()
-                .email("admin@example.com")
-                .password("encodedPassword")
-                .adminName("관리자")
-                .adminPhone("010-0000-0000")
-                .role(Admin.AdminRole.CS_ADMIN)
-                .status(Admin.AdminStatus.ACTIVE)
-                .build();
+        Admin admin = csAdmin();
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
 
@@ -228,14 +221,7 @@ class AdminProductApprovalServiceImplTest {
     void 상품_승인_거절_실패_DB관리자권한없음() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        Admin admin = Admin.builder()
-                .email("admin@example.com")
-                .password("encodedPassword")
-                .adminName("관리자")
-                .adminPhone("010-0000-0000")
-                .role(Admin.AdminRole.CS_ADMIN)
-                .status(Admin.AdminStatus.ACTIVE)
-                .build();
+        Admin admin = csAdmin();
         ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
@@ -370,6 +356,17 @@ class AdminProductApprovalServiceImplTest {
                 .adminName("관리자")
                 .adminPhone("010-0000-0000")
                 .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+    }
+
+    private Admin csAdmin() {
+        return Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.CS_ADMIN)
                 .status(Admin.AdminStatus.ACTIVE)
                 .build();
     }

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/AdminProductApprovalServiceImplTest.java
@@ -169,7 +169,39 @@ class AdminProductApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 실패 - 이미 거절된 상품")
+    void 상품_승인_실패_이미거절됨() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(product(Product.ApprovalStatus.REJECTED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 실패 - 정지된 상품")
+    void 상품_승인_실패_정지됨() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(product(Product.ApprovalStatus.SUSPENDED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.approveProduct(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
         verify(productApprovalRepository, never()).save(any());
     }
 
@@ -247,7 +279,43 @@ class AdminProductApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - 이미 거절된 상품")
+    void 상품_승인_거절_실패_이미거절됨() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(product(Product.ApprovalStatus.REJECTED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - 정지된 상품")
+    void 상품_승인_거절_실패_정지됨() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ProductRejectRequestDto request = new ProductRejectRequestDto("상품 설명 보완 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(product(Product.ApprovalStatus.SUSPENDED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
         verify(productApprovalRepository, never()).save(any());
     }
 
@@ -265,8 +333,26 @@ class AdminProductApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REJECT_REASON_REQUIRED);
         assertThat(product.getApprovalStatus()).isEqualTo(Product.ApprovalStatus.PENDING);
+        verify(productApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("상품 승인 거절 실패 - 처리된 상품은 거절 사유보다 상태를 먼저 검증")
+    void 상품_승인_거절_실패_처리된상품_상태검증우선() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ProductRejectRequestDto request = new ProductRejectRequestDto(" ");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(productRepository.findByProductIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(product(Product.ApprovalStatus.APPROVED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminProductApprovalService.rejectProduct(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
         verify(productApprovalRepository, never()).save(any());
     }
 

--- a/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
@@ -25,9 +25,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AdminSellerApprovalServiceImplTest {
@@ -52,10 +52,10 @@ class AdminSellerApprovalServiceImplTest {
         Admin admin = superAdmin();
         Seller seller = seller(SellerStatus.PENDING);
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
-        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller));
-        when(sellerApprovalRepository.save(any(SellerApproval.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerApprovalRepository.save(any(SellerApproval.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         SellerApprovalResponseDto result = adminSellerApprovalService.approveSeller(adminInfo, 1L);
@@ -82,10 +82,10 @@ class AdminSellerApprovalServiceImplTest {
         Seller seller = seller(SellerStatus.PENDING);
         SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
-        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller));
-        when(sellerApprovalRepository.save(any(SellerApproval.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerApprovalRepository.save(any(SellerApproval.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         SellerApprovalResponseDto result = adminSellerApprovalService.rejectSeller(adminInfo, 1L, request);
@@ -113,7 +113,7 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
         verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
@@ -123,13 +123,13 @@ class AdminSellerApprovalServiceImplTest {
     void 판매자_승인_실패_판매자없음() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
-        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 999L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.SELLER_NOT_FOUND.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SELLER_NOT_FOUND);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -147,12 +147,12 @@ class AdminSellerApprovalServiceImplTest {
                 .status(Admin.AdminStatus.ACTIVE)
                 .build();
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
         verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
@@ -162,13 +162,90 @@ class AdminSellerApprovalServiceImplTest {
     void 판매자_승인_실패_상태전이불가() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
-        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller(SellerStatus.APPROVED)));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - SUPER_ADMIN 권한 없음")
+    void 판매자_승인_거절_실패_권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.CS_ADMIN)
+                .build();
+        SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - DB 기준 관리자 권한 없음")
+    void 판매자_승인_거절_실패_DB관리자권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.CS_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+        SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - 판매자 없음")
+    void 판매자_승인_거절_실패_판매자없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 999L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SELLER_NOT_FOUND);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - PENDING 상태가 아님")
+    void 판매자_승인_거절_실패_상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -180,13 +257,13 @@ class AdminSellerApprovalServiceImplTest {
         Seller seller = seller(SellerStatus.PENDING);
         SellerRejectRequestDto request = new SellerRejectRequestDto(" ");
 
-        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
-        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller));
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
         assertThat(seller.getStatus()).isEqualTo(SellerStatus.PENDING);
         verify(sellerApprovalRepository, never()).save(any());
     }

--- a/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
@@ -1,0 +1,223 @@
+package co.kr.allpick.domain.admin.seller.service.impl;
+
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.domain.admin.seller.dto.SellerApprovalResponseDto;
+import co.kr.allpick.domain.admin.seller.dto.SellerRejectRequestDto;
+import co.kr.allpick.domain.admin.seller.entity.SellerApproval;
+import co.kr.allpick.domain.admin.seller.repository.SellerApprovalRepository;
+import co.kr.allpick.domain.seller.entity.Seller;
+import co.kr.allpick.domain.seller.entity.SellerStatus;
+import co.kr.allpick.domain.seller.repository.SellerRepository;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminSellerApprovalServiceImplTest {
+
+    @Mock
+    SellerRepository sellerRepository;
+
+    @Mock
+    AdminRepository adminRepository;
+
+    @Mock
+    SellerApprovalRepository sellerApprovalRepository;
+
+    @InjectMocks
+    AdminSellerApprovalServiceImpl adminSellerApprovalService;
+
+    @Test
+    @DisplayName("판매자 승인 성공")
+    void 판매자_승인_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = superAdmin();
+        Seller seller = seller(SellerStatus.PENDING);
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller));
+        when(sellerApprovalRepository.save(any(SellerApproval.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        SellerApprovalResponseDto result = adminSellerApprovalService.approveSeller(adminInfo, 1L);
+
+        // then
+        assertThat(seller.getStatus()).isEqualTo(SellerStatus.APPROVED);
+        assertThat(result.getStatus()).isEqualTo(SellerApproval.ApprovalStatus.APPROVED);
+        assertThat(result.getRequestType()).isEqualTo(SellerApproval.RequestType.REGISTER);
+
+        ArgumentCaptor<SellerApproval> captor = ArgumentCaptor.forClass(SellerApproval.class);
+        verify(sellerApprovalRepository).save(captor.capture());
+        assertThat(captor.getValue().getSeller()).isEqualTo(seller);
+        assertThat(captor.getValue().getAdmin()).isEqualTo(admin);
+        assertThat(captor.getValue().getRejectReason()).isNull();
+        assertThat(captor.getValue().getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 성공")
+    void 판매자_승인_거절_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = superAdmin();
+        Seller seller = seller(SellerStatus.PENDING);
+        SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller));
+        when(sellerApprovalRepository.save(any(SellerApproval.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        SellerApprovalResponseDto result = adminSellerApprovalService.rejectSeller(adminInfo, 1L, request);
+
+        // then
+        assertThat(seller.getStatus()).isEqualTo(SellerStatus.REJECTED);
+        assertThat(result.getStatus()).isEqualTo(SellerApproval.ApprovalStatus.REJECTED);
+        assertThat(result.getRejectReason()).isEqualTo("사업자등록번호 확인 필요");
+
+        ArgumentCaptor<SellerApproval> captor = ArgumentCaptor.forClass(SellerApproval.class);
+        verify(sellerApprovalRepository).save(captor.capture());
+        assertThat(captor.getValue().getRejectReason()).isEqualTo("사업자등록번호 확인 필요");
+        assertThat(captor.getValue().getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("판매자 승인 실패 - SUPER_ADMIN 권한 없음")
+    void 판매자_승인_실패_권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.CS_ADMIN)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 실패 - 판매자 없음")
+    void 판매자_승인_실패_판매자없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
+        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.SELLER_NOT_FOUND.getMessage());
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 실패 - DB 기준 관리자 권한 없음")
+    void 판매자_승인_실패_DB관리자권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin admin = Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.CS_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(admin));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ADMIN_FORBIDDEN.getMessage());
+        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 실패 - PENDING 상태가 아님")
+    void 판매자_승인_실패_상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
+        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller(SellerStatus.APPROVED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - 거절 사유 없음")
+    void 판매자_승인_거절_실패_거절사유없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Seller seller = seller(SellerStatus.PENDING);
+        SellerRejectRequestDto request = new SellerRejectRequestDto(" ");
+
+        when(adminRepository.findById(adminInfo.getAdminId())).thenReturn(Optional.of(superAdmin()));
+        when(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(seller));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_INPUT.getMessage());
+        assertThat(seller.getStatus()).isEqualTo(SellerStatus.PENDING);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    private AdminJwtUserInfoDto superAdminInfo() {
+        return AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .build();
+    }
+
+    private Admin superAdmin() {
+        return Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+    }
+
+    private Seller seller(SellerStatus status) {
+        return Seller.builder()
+                .sellerId(1L)
+                .businessName("올픽상점")
+                .businessNumber("123-45-67890")
+                .representativeName("대표자")
+                .bankName("은행")
+                .bankAccount("1234567890")
+                .status(status)
+                .build();
+    }
+}

--- a/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
@@ -138,14 +138,7 @@ class AdminSellerApprovalServiceImplTest {
     void 판매자_승인_실패_DB관리자권한없음() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        Admin admin = Admin.builder()
-                .email("admin@example.com")
-                .password("encodedPassword")
-                .adminName("관리자")
-                .adminPhone("010-0000-0000")
-                .role(Admin.AdminRole.CS_ADMIN)
-                .status(Admin.AdminStatus.ACTIVE)
-                .build();
+        Admin admin = csAdmin();
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
 
@@ -168,7 +161,37 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 실패 - REJECTED 상태는 처리 불가")
+    void 판매자_승인_실패_REJECTED상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.REJECTED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 실패 - SUSPENDED 상태는 처리 불가")
+    void 판매자_승인_실패_SUSPENDED상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.SUSPENDED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -195,14 +218,7 @@ class AdminSellerApprovalServiceImplTest {
     void 판매자_승인_거절_실패_DB관리자권한없음() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        Admin admin = Admin.builder()
-                .email("admin@example.com")
-                .password("encodedPassword")
-                .adminName("관리자")
-                .adminPhone("010-0000-0000")
-                .role(Admin.AdminRole.CS_ADMIN)
-                .status(Admin.AdminStatus.ACTIVE)
-                .build();
+        Admin admin = csAdmin();
         SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
@@ -245,7 +261,41 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - REJECTED 상태는 처리 불가")
+    void 판매자_승인_거절_실패_REJECTED상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.REJECTED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - SUSPENDED 상태는 처리 불가")
+    void 판매자_승인_거절_실패_SUSPENDED상태전이불가() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.SUSPENDED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -263,8 +313,25 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REJECT_REASON_REQUIRED);
         assertThat(seller.getStatus()).isEqualTo(SellerStatus.PENDING);
+        verify(sellerApprovalRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("판매자 승인 거절 실패 - 처리 완료 상태가 거절 사유보다 우선")
+    void 판매자_승인_거절_실패_처리완료상태가거절사유보다우선() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        SellerRejectRequestDto request = new SellerRejectRequestDto(" ");
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
+
+        // when & then
+        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -282,6 +349,17 @@ class AdminSellerApprovalServiceImplTest {
                 .adminName("관리자")
                 .adminPhone("010-0000-0000")
                 .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+    }
+
+    private Admin csAdmin() {
+        return Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.CS_ADMIN)
                 .status(Admin.AdminStatus.ACTIVE)
                 .build();
     }

--- a/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
@@ -161,7 +161,7 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_NOT_PENDING);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -176,7 +176,7 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_NOT_PENDING);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -191,7 +191,7 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_NOT_PENDING);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -261,7 +261,7 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_NOT_PENDING);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -278,7 +278,7 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_NOT_PENDING);
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -295,43 +295,7 @@ class AdminSellerApprovalServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
-        verify(sellerApprovalRepository, never()).save(any());
-    }
-
-    @Test
-    @DisplayName("판매자 승인 거절 실패 - 거절 사유 없음")
-    void 판매자_승인_거절_실패_거절사유없음() {
-        // given
-        AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        Seller seller = seller(SellerStatus.PENDING);
-        SellerRejectRequestDto request = new SellerRejectRequestDto(" ");
-
-        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
-
-        // when & then
-        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REJECT_REASON_REQUIRED);
-        assertThat(seller.getStatus()).isEqualTo(SellerStatus.PENDING);
-        verify(sellerApprovalRepository, never()).save(any());
-    }
-
-    @Test
-    @DisplayName("판매자 승인 거절 실패 - 처리 완료 상태가 거절 사유보다 우선")
-    void 판매자_승인_거절_실패_처리완료상태가거절사유보다우선() {
-        // given
-        AdminJwtUserInfoDto adminInfo = superAdminInfo();
-        SellerRejectRequestDto request = new SellerRejectRequestDto(" ");
-
-        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
-
-        // when & then
-        assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_ALREADY_PROCESSED);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPROVAL_NOT_PENDING);
         verify(sellerApprovalRepository, never()).save(any());
     }
 


### PR DESCRIPTION
## 구현 내용

- `domain/admin/product/`에 상품 승인 기능 추가
- 관리자(SUPER_ADMIN)가 PENDING 상태 상품을 승인/거절하는 API
- 승인 이력을 `product_approvals` 테이블에 저장 (ERD 기반)
- `Product` 엔티티에 `approve()`, `reject()` 명시적 변경 메서드 추가
- `Product.ApprovalStatus`에 `REJECTED` 추가

## API

| Method | URL | 설명 |
|---|---|---|
| PATCH | `/api/admin/products/{productId}/approve` | 상품 승인 |
| PATCH | `/api/admin/products/{productId}/reject` | 상품 거절 (rejectReason 필수) |

## 변경 파일

- `domain/admin/product/` — 신규 (Controller, Docs, Service, ServiceImpl, Repository, Entity, DTO)
- `domain/product/entity/Product.java` — approve/reject 메서드 추가, REJECTED 상태 추가
- `domain/product/repository/ProductRepository.java` — findByProductIdAndDeletedAtIsNull 추가
- `global/exception/ErrorCode.java` — PR #66 머지 반영 (APPROVAL_NOT_PENDING 사용)

## 참고

- PR #66(판매자 승인) 머지 후 develop 반영하여 `ErrorCode` 충돌 정리 완료
- 거절 사유 검증은 DTO `@NotBlank` + `@Valid`에 위임 (서비스 중복 검증 제거)