### PR TITLE
feat: FaqServiceImplTest deleteFaq_success 테스트 상태 검증 추가

### DIFF
--- a/src/test/java/co/kr/allpick/domain/admin/board/service/impl/FaqServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/board/service/impl/FaqServiceImplTest.java
@@ -166,13 +166,14 @@ public class FaqServiceImplTest {
     void deleteFaq_success() {
         // given
         Long faqId = 1L;
-        given(faqRepository.findById(faqId)).willReturn(Optional.of(createFaq()));
+        Faq faq = createFaq();
+        given(faqRepository.findById(faqId)).willReturn(Optional.of(faq));
 
         // when
         faqService.deleteFaq(faqId);
 
         // then
-        then(faqRepository).should().findById(faqId);
+        assertThat(faq.getDeletedAt()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## 개요
- FaqServiceImplTest deleteFaq_success 테스트 상태검증 추가

---

## 작업 내용
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller:
- Service:
- Repository:
- 기타: FaqServiceImplTest.deleteFaq_success()에서 createFaq()를 변수로 분리하고
        소프트 딜리트 상태검증(assertThat(faq.getDeletedAt()).isNotNull()) 추가

---

## 관련 이슈
- close #68 

---

## 변경 전 / 후
### Before
- deleteFaq_success 테스트가 findById 호출 여부만 확인하는 행위검증만 존재

### After
- faq.delete() 호출 후 deletedAt 필드가 설정되는지 상태검증 추가
- NoticeServiceImplTest.공지사항_삭제_성공()과 동일한 패턴으로 통일