### PR TITLE
feat: MemberController에 이메일 중복 확인 API 추가

### DIFF
--- a/src/main/java/co/kr/allpick/domain/member/controller/MemberController.java
+++ b/src/main/java/co/kr/allpick/domain/member/controller/MemberController.java
@@ -1,16 +1,22 @@
 package co.kr.allpick.domain.member.controller;
 
-import co.kr.allpick.domain.member.docs.MemberControllerDocs;
-import co.kr.allpick.domain.member.dto.MemberResponseDto;
-import co.kr.allpick.domain.member.service.MemberService;
-import co.kr.allpick.global.config.JwtUserInfoDto;
-import co.kr.allpick.global.response.ApiResponse;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+
+import co.kr.allpick.domain.member.docs.MemberControllerDocs;
+import co.kr.allpick.domain.member.dto.MemberResponseDto;
+import co.kr.allpick.domain.member.repository.MemberRepository;
+import co.kr.allpick.domain.member.service.MemberService;
+import co.kr.allpick.global.config.JwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/members")
@@ -18,11 +24,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberControllerDocs {
 
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
     @Override
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MemberResponseDto>> getMember(
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
         return ApiResponse.success("회원 정보 조회 성공", memberService.getMember(userInfo.getMemberId()));
+    }
+    @GetMapping("/check-email")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkEmail(
+            @RequestParam("email") String email) {
+        boolean exists = memberRepository.existsByEmail(email);
+        return ApiResponse.success("이메일 확인 완료", Map.of("available", !exists));
     }
 }

--- a/src/main/java/co/kr/allpick/domain/member/docs/MemberControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/member/docs/MemberControllerDocs.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import java.util.Map;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Member", description = "회원 API")
 public interface MemberControllerDocs {
@@ -40,4 +42,5 @@ public interface MemberControllerDocs {
             """)))
     })
     ResponseEntity<ApiResponse<MemberResponseDto>> getMember(JwtUserInfoDto userInfo);
+    ResponseEntity<ApiResponse<Map<String, Boolean>>> checkEmail(@RequestParam("email") String email);
 }

--- a/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
+++ b/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
+            	.requestMatchers("/api/members/check-email").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/api/admins/login").permitAll()
                 .requestMatchers("/api/seller/auth/login").permitAll()


### PR DESCRIPTION
## 개요
이메일 중복 확인 API 추가 및 Security 설정 보완

---
## 작업 내용
- [x] 기능 추가
- [x] 버그 수정

### 주요 변경 사항
- Controller: MemberController에 GET /api/members/check-email 엔드포인트 추가
- Service: 없음
- Repository: MemberRepository.existsByEmail() 활용
- 기타: 
  - SecurityConfig에 /api/members/check-email permitAll 추가
  - MemberControllerDocs에 checkEmail 메서드 선언 추가

---
## 관련 이슈
- 관련 이슈: #이슈번호

---
## 변경 전 / 후
### Before
- 이메일 중복 확인 API가 없어 프론트에서 500 에러 발생
- /api/auth/check-email 경로로 요청 시 NoResourceFoundException 발생
- Security 설정에 check-email 경로가 누락되어 403 에러 발생

### After
- GET /api/members/check-email?email={email} API 추가
- 이메일 존재 여부를 { available: true/false } 형태로 응답
- Security permitAll 설정으로 비로그인 상태에서도 호출 가능