### PR TITLE
fix: 관리자 회원 관리 권한 검증 보완

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/member/controller/AdminMemberController.java
@@ -1,5 +1,6 @@
 package co.kr.allpick.domain.admin.member.controller;
 
+import co.kr.allpick.domain.admin.member.controller.docs.AdminMemberControllerDocs;
 import co.kr.allpick.domain.admin.member.dto.MemberListResponseDto;
 import co.kr.allpick.domain.admin.member.service.AdminMemberService;
 import co.kr.allpick.global.config.AdminJwtUserInfoDto;
@@ -18,12 +19,13 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/members")
-public class AdminMemberController {
+public class AdminMemberController implements AdminMemberControllerDocs {
 
     private final AdminMemberService adminMemberService;
 
     // GET /api/admin/members → 구매자 전체 목록
     @GetMapping
+    @Override
     public ResponseEntity<ApiResponse<List<MemberListResponseDto>>> getMembers(
             @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo) {
         return ApiResponse.success("구매자 목록 조회 성공",
@@ -32,6 +34,7 @@ public class AdminMemberController {
 
     // PATCH /api/admin/members/{memberId}/status → 활성/정지 토글
     @PatchMapping("/{memberId}/status")
+    @Override
     public ResponseEntity<ApiResponse<Void>> toggleStatus(
             @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
             @PathVariable Long memberId) {

--- a/src/main/java/co/kr/allpick/domain/admin/member/controller/docs/AdminMemberControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/member/controller/docs/AdminMemberControllerDocs.java
@@ -1,0 +1,36 @@
+package co.kr.allpick.domain.admin.member.controller.docs;
+
+import co.kr.allpick.domain.admin.member.dto.MemberListResponseDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(name = "Admin Member", description = "관리자 구매자 관리 API")
+public interface AdminMemberControllerDocs {
+
+    @Operation(summary = "구매자 목록 조회", description = "SUPER_ADMIN이 구매자 회원 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구매자 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "SUPER_ADMIN 권한 없음")
+    })
+    ResponseEntity<ApiResponse<List<MemberListResponseDto>>> getMembers(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo);
+
+    @Operation(summary = "구매자 상태 변경", description = "SUPER_ADMIN이 구매자 회원 상태를 활성/정지로 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 상태 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "SUPER_ADMIN 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 없음")
+    })
+    ResponseEntity<ApiResponse<Void>> toggleStatus(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @Parameter(description = "구매자 회원 ID") @PathVariable("memberId") Long memberId);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImpl.java
@@ -1,7 +1,9 @@
 package co.kr.allpick.domain.admin.member.service.impl;
 
+import co.kr.allpick.domain.admin.entity.Admin;
 import co.kr.allpick.domain.admin.member.dto.MemberListResponseDto;
 import co.kr.allpick.domain.admin.member.service.AdminMemberService;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
 import co.kr.allpick.domain.member.entity.Member;
 import co.kr.allpick.domain.member.repository.MemberRepository;
 import co.kr.allpick.global.config.AdminJwtUserInfoDto;
@@ -19,10 +21,12 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class AdminMemberServiceImpl implements AdminMemberService {
 
+    private final AdminRepository adminRepository;
     private final MemberRepository memberRepository;
 
     @Override
     public List<MemberListResponseDto> getMembers(AdminJwtUserInfoDto adminInfo) {
+        getSuperAdmin(adminInfo);
         return memberRepository.findAllByOrderByCreatedAtDesc()
                 .stream()
                 .map(MemberListResponseDto::from)
@@ -32,9 +36,22 @@ public class AdminMemberServiceImpl implements AdminMemberService {
     @Override
     @Transactional
     public void toggleMemberStatus(AdminJwtUserInfoDto adminInfo, Long memberId) {
+        getSuperAdmin(adminInfo);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         if (member.getStatus() == 1) member.suspend();
         else member.activate();
+    }
+
+    private Admin getSuperAdmin(AdminJwtUserInfoDto adminInfo) {
+        if (adminInfo == null || adminInfo.getRole() != Admin.AdminRole.SUPER_ADMIN) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+        Admin admin = adminRepository.findById(adminInfo.getAdminId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+        if (admin.getRole() != Admin.AdminRole.SUPER_ADMIN || admin.getStatus() != Admin.AdminStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+        return admin;
     }
 }

--- a/src/main/java/co/kr/allpick/domain/member/service/impl/AuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/member/service/impl/AuthServiceImpl.java
@@ -66,6 +66,10 @@ public class AuthServiceImpl implements AuthService {
             logger.warn("[AuthService] 비밀번호 불일치 - memberId: {}", member.getId());
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
+        if (!Integer.valueOf(1).equals(member.getStatus())) {
+            logger.warn("[AuthService] 정지 회원 로그인 시도 - memberId: {}", member.getId());
+            throw new BusinessException(ErrorCode.MEMBER_BLOCKED);
+        }
         logger.info("[AuthService] 로그인 성공 - memberId: {}", member.getId());
 
         String token = jwtProvider.createToken(JwtUserInfoDto.builder()

--- a/src/main/java/co/kr/allpick/domain/product/dto/ProductImageRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/product/dto/ProductImageRequestDto.java
@@ -15,9 +15,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-
-@Getter
-@NoArgsConstructor
 @Schema(description = "상품이미지 생성 요청dto")
 public class ProductImageRequestDto {
 	
@@ -35,7 +32,6 @@ public class ProductImageRequestDto {
 		return ProductImage.builder()
 				.productImageId(this.productImageId)
 				.imageUrl(this.imageUrl)
-				.product(product)
 				.sortOrder(this.sortOrder)
 				.product(product)
 				.build();

--- a/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
@@ -95,6 +95,10 @@ public class SellerAuthServiceImpl implements SellerAuthService {
             logger.warn("[SellerAuthService] 비밀번호 불일치 - memberId: {}", member.getId());
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
+        if (!Integer.valueOf(1).equals(member.getStatus())) {
+            logger.warn("[SellerAuthService] 정지 회원 판매자 로그인 시도 - memberId: {}", member.getId());
+            throw new BusinessException(ErrorCode.MEMBER_BLOCKED);
+        }
         Seller seller = sellerRepository.findByMemberIdAndDeletedAtIsNull(member.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_SELLER));
 

--- a/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
+++ b/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/admins").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admins/*/status").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers("/api/admin/members/**").hasAuthority("ROLE_SUPER_ADMIN")
+                .requestMatchers("/api/admin/sellers/**").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admin/products/*/approve").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admin/products/*/reject").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.GET, "/api/faqs/**").permitAll()

--- a/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
+++ b/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/admins").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admins/*/status").hasAuthority("ROLE_SUPER_ADMIN")
+                .requestMatchers("/api/admin/members/**").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admin/products/*/approve").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admin/products/*/reject").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.GET, "/api/faqs/**").permitAll()

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     NOT_SELLER(HttpStatus.FORBIDDEN, "NOT_SELLER", "판매자 권한이 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "회원을 찾을 수 없습니다."),
+    MEMBER_BLOCKED(HttpStatus.FORBIDDEN, "MEMBER_BLOCKED", "정지된 회원 계정입니다."),
     UNAUTHORIZED(HttpStatus.FORBIDDEN, "UNAUTHORIZED", "본인만 접근 가능합니다."),
     PRODUCT_NOT_OWNED(HttpStatus.FORBIDDEN, "PRODUCT_NOT_OWNED", "해당 상품에 대한 권한이 없습니다."),
     

--- a/src/test/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImplTest.java
@@ -1,8 +1,11 @@
 package co.kr.allpick.domain.admin.member.service.impl;
 
+import co.kr.allpick.domain.admin.entity.Admin;
 import co.kr.allpick.domain.admin.member.dto.MemberListResponseDto;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
 import co.kr.allpick.domain.member.entity.Member;
 import co.kr.allpick.domain.member.repository.MemberRepository;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
 import co.kr.allpick.global.exception.BusinessException;
 import co.kr.allpick.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +26,9 @@ import static org.mockito.BDDMockito.given;
 class AdminMemberServiceImplTest {
 
     @Mock
+    AdminRepository adminRepository;
+
+    @Mock
     MemberRepository memberRepository;
 
     @InjectMocks
@@ -34,10 +40,11 @@ class AdminMemberServiceImplTest {
         // given
         Member m1 = member(1L, 1);
         Member m2 = member(2L, 0);
+        given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
         given(memberRepository.findAllByOrderByCreatedAtDesc()).willReturn(List.of(m1, m2));
 
         // when
-        List<MemberListResponseDto> result = adminMemberService.getMembers(null);
+        List<MemberListResponseDto> result = adminMemberService.getMembers(superAdminInfo());
 
         // then
         assertThat(result).hasSize(2);
@@ -50,10 +57,11 @@ class AdminMemberServiceImplTest {
     void 구매자_정지_성공() {
         // given
         Member member = member(1L, 1);
+        given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
         given(memberRepository.findById(1L)).willReturn(Optional.of(member));
 
         // when
-        adminMemberService.toggleMemberStatus(null, 1L);
+        adminMemberService.toggleMemberStatus(superAdminInfo(), 1L);
 
         // then
         assertThat(member.getStatus()).isEqualTo(0);
@@ -64,10 +72,11 @@ class AdminMemberServiceImplTest {
     void 구매자_활성화_성공() {
         // given
         Member member = member(1L, 0);
+        given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
         given(memberRepository.findById(1L)).willReturn(Optional.of(member));
 
         // when
-        adminMemberService.toggleMemberStatus(null, 1L);
+        adminMemberService.toggleMemberStatus(superAdminInfo(), 1L);
 
         // then
         assertThat(member.getStatus()).isEqualTo(1);
@@ -77,12 +86,55 @@ class AdminMemberServiceImplTest {
     @DisplayName("상태변경 실패 - 회원 없음")
     void 상태변경_실패_회원없음() {
         // given
+        given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
         given(memberRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> adminMemberService.toggleMemberStatus(null, 999L))
+        assertThatThrownBy(() -> adminMemberService.toggleMemberStatus(superAdminInfo(), 999L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("구매자 목록 조회 실패 - 관리자 정보 없음")
+    void 구매자_목록_조회_실패_관리자정보없음() {
+        // when & then
+        assertThatThrownBy(() -> adminMemberService.getMembers(null))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("구매자 목록 조회 실패 - CS 관리자 권한")
+    void 구매자_목록_조회_실패_CS관리자권한() {
+        // when & then
+        assertThatThrownBy(() -> adminMemberService.getMembers(csAdminInfo()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("구매자 목록 조회 실패 - 관리자 없음")
+    void 구매자_목록_조회_실패_관리자없음() {
+        // given
+        given(adminRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberService.getMembers(superAdminInfo()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("구매자 상태변경 실패 - 비활성 관리자")
+    void 구매자_상태변경_실패_비활성관리자() {
+        // given
+        given(adminRepository.findById(1L)).willReturn(Optional.of(blockedSuperAdmin()));
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberService.toggleMemberStatus(superAdminInfo(), 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
     }
 
     private Member member(Long id, int status) {
@@ -92,6 +144,36 @@ class AdminMemberServiceImplTest {
                 .phone("010-0000-000" + id)
                 .address("서울시")
                 .status(status)
+                .build();
+    }
+
+    private AdminJwtUserInfoDto superAdminInfo() {
+        return new AdminJwtUserInfoDto(1L, "admin@example.com", Admin.AdminRole.SUPER_ADMIN);
+    }
+
+    private AdminJwtUserInfoDto csAdminInfo() {
+        return new AdminJwtUserInfoDto(2L, "cs@example.com", Admin.AdminRole.CS_ADMIN);
+    }
+
+    private Admin superAdmin() {
+        return Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+    }
+
+    private Admin blockedSuperAdmin() {
+        return Admin.builder()
+                .email("blocked@example.com")
+                .password("encodedPassword")
+                .adminName("차단관리자")
+                .adminPhone("010-0000-0001")
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.BLOCKED)
                 .build();
     }
 }

--- a/src/test/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImplTest.java
@@ -139,6 +139,7 @@ class AdminMemberServiceImplTest {
 
     private Member member(Long id, int status) {
         return Member.builder()
+                .id(id)
                 .email("test" + id + "@example.com")
                 .name("테스터" + id)
                 .phone("010-0000-000" + id)

--- a/src/test/java/co/kr/allpick/domain/member/service/Impl/AuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/member/service/Impl/AuthServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
 
@@ -167,5 +168,27 @@ class AuthServiceImplTest {
         assertThatThrownBy(() -> authService.login(dto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 정지 회원")
+    void 로그인_실패_정지회원() {
+        LoginRequestDto dto = new LoginRequestDto("blocked@test.com", "password123");
+
+        Member mockMember = Member.builder()
+                .email("blocked@test.com")
+                .password("encodedPassword")
+                .name("정지회원")
+                .phone("010-1234-5678")
+                .address("서울시 강남구")
+                .status(0)
+                .build();
+
+        given(memberRepository.findByEmail(dto.getEmail())).willReturn(Optional.of(mockMember));
+        given(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).willReturn(true);
+
+        assertThatThrownBy(() -> authService.login(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_BLOCKED);
     }
 }

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
@@ -236,6 +236,27 @@ class SellerAuthServiceImplTest {
                 .hasMessage(ErrorCode.NOT_SELLER.getMessage());
     }
 
+    @Test
+    @DisplayName("판매자 로그인 실패 - 정지 회원")
+    void login_blockedMember_throwException() {
+        // given
+        SellerLoginRequestDto dto = new SellerLoginRequestDto("blocked@test.com", "password123");
+
+        Member mockMember = Member.builder()
+                .email("blocked@test.com")
+                .password("encodedPassword")
+                .status(0)
+                .build();
+
+        given(memberRepository.findByEmail(dto.getEmail())).willReturn(Optional.of(mockMember));
+        given(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> sellerAuthService.login(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_BLOCKED);
+    }
+
     // ==================== 판매자 삭제 ====================
 
     @Test


### PR DESCRIPTION
﻿## 개요
- 관리자 회원 관리 API의 권한 검증을 보완하고 정지 회원 로그인 차단을 반영했습니다.

---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [x] 문서 수정

### 주요 변경 사항
- Controller:
  - `AdminMemberControllerDocs` 추가 및 `AdminMemberController`에 Swagger Docs 인터페이스 적용
- Service:
  - `AdminMemberServiceImpl`에서 SUPER_ADMIN 권한과 DB 관리자 상태 재검증
  - 일반 로그인/판매자 로그인 시 정지 회원 차단
- Repository:
  - 없음
- 기타:
  - `/api/admin/members/**`, `/api/admin/sellers/**` SecurityConfig 권한 제한 추가
  - `MEMBER_BLOCKED` ErrorCode 추가
  - `AdminMemberServiceImplTest` 권한/상태 변경 테스트 보완
  - @gungang1212-tech `ProductImageRequestDto.java`의 중복 Lombok 어노테이션과 중복 `product(product)` 호출 때문에 compileJava가 실패해, 컴파일 차단 해소용으로 중복 선언만 최소 제거했습니다.

---

## 관련 이슈
- 관련 이슈: 없음

---

## 변경 전 / 후
### Before
- `/api/admin/members/**`가 SecurityConfig에서 SUPER_ADMIN 권한으로 제한되지 않았습니다.
- 서비스 레벨에서 관리자 권한을 재검증하지 않아 일반 인증 사용자가 관리자 회원 API에 도달할 위험이 있었습니다.
- 관리자가 회원을 정지해도 해당 회원이 일반 로그인/판매자 로그인을 계속할 수 있었습니다.
- `ProductImageRequestDto.java` 중복 선언으로 `compileJava`가 실패해 관리자 회원 테스트가 실행되지 못했습니다.

### After
- 관리자 회원/판매자 관리 API 경로를 SUPER_ADMIN 권한으로 제한했습니다.
- 서비스에서 `adminInfo`, 관리자 role, 관리자 status를 재검증합니다.
- 정지 회원은 일반 로그인과 판매자 로그인이 차단됩니다.
- `AdminMemberServiceImplTest`가 실행 및 성공하는 상태로 복구했습니다.

검증:
- `./gradlew.bat test --tests co.kr.allpick.domain.admin.member.service.impl.AdminMemberServiceImplTest` 성공
- `./gradlew.bat test`는 컴파일 통과 후 기존 테스트 2건 실패 확인
  - `AllPickApplicationTests > contextLoads()`
  - `SellerApplyServiceImplTest > 이미 판매자 신청한 회원일 경우 예외 발생`
