### PR TITLE
feat: add member order cancel api

### DIFF
--- a/src/main/java/co/kr/allpick/domain/order/controller/OrderController.java
+++ b/src/main/java/co/kr/allpick/domain/order/controller/OrderController.java
@@ -49,6 +49,14 @@ public class OrderController implements OrderControllerDocs {
     }
 
     @Override
+    @PatchMapping("/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<OrderResponseDto>> cancelOrder(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable("orderId") Long orderId) {
+        return ApiResponse.success("주문 취소 성공.", orderService.cancelOrder(userInfo.getMemberId(), orderId));
+    }
+
+    @Override
     @GetMapping("/{orderId}/payment")
     public ResponseEntity<ApiResponse<PaymentResponseDto>> getPayment(
             @PathVariable("orderId") Long orderId) {

--- a/src/main/java/co/kr/allpick/domain/order/controller/docs/OrderControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/order/controller/docs/OrderControllerDocs.java
@@ -54,6 +54,18 @@ public interface OrderControllerDocs {
     @GetMapping("/{orderId}")
     ResponseEntity<ApiResponse<OrderResponseDto>> getOrder(@PathVariable("orderId") Long orderId);
 
+    @Operation(summary = "주문 취소", description = "현재 로그인한 회원의 주문을 취소합니다. 주문 완료 상태(PENDING)에서만 취소할 수 있습니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "주문 취소 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "취소할 수 없는 주문 상태"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인 주문이 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음")
+    })
+    @PatchMapping("/{orderId}/cancel")
+    ResponseEntity<ApiResponse<OrderResponseDto>> cancelOrder(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable("orderId") Long orderId);
+
     @Operation(summary = "결제 정보 조회", description = "주문 ID에 연결된 결제 상세 정보를 조회합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "결제 정보 조회 성공",

--- a/src/main/java/co/kr/allpick/domain/order/service/OrderService.java
+++ b/src/main/java/co/kr/allpick/domain/order/service/OrderService.java
@@ -14,6 +14,8 @@ public interface OrderService {
 
     OrderResponseDto getOrder(Long orderId);
 
+    OrderResponseDto cancelOrder(Long memberId, Long orderId);
+
     PaymentResponseDto getPayment(Long orderId);
 
     DeliveryAddressResponseDto addDeliveryAddress(Long memberId, DeliveryAddressRequestDto request);

--- a/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java
@@ -149,6 +149,22 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @Transactional
+    public OrderResponseDto cancelOrder(Long memberId, Long orderId) {
+        logger.info("주문 취소 요청 - memberId: {}, orderId: {}", memberId, orderId);
+        Order order = orderRepository.findByIdWithItems(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        validateOrderOwner(memberId, order);
+        validateOrderCancelable(order);
+        restoreOrderItemStock(order);
+        order.updateStatus(Order.OrderStatus.CANCELLED);
+
+        logger.info("주문 취소 완료 - orderId: {}", orderId);
+        return OrderResponseDto.from(order, order.getOrderItems());
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public PaymentResponseDto getPayment(Long orderId) {
         logger.info("결제 조회 - orderId: {}", orderId);
@@ -220,6 +236,24 @@ public class OrderServiceImpl implements OrderService {
         if (orderRepository.existsByDeliveryAddress_AddressId(addressId)) {
             throw new BusinessException(ErrorCode.ADDRESS_CANNOT_MODIFY);
         }
+    }
+
+    private void validateOrderOwner(Long memberId, Order order) {
+        if (!order.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ORDER);
+        }
+    }
+
+    private void validateOrderCancelable(Order order) {
+        if (order.getStatus() != Order.OrderStatus.PENDING) {
+            throw new BusinessException(ErrorCode.ORDER_CANNOT_CANCEL);
+        }
+    }
+
+    private void restoreOrderItemStock(Order order) {
+        order.getOrderItems().forEach(orderItem ->
+                orderItem.getProductOption().restoreStock(orderItem.getQuantity())
+        );
     }
 
     // 중복 없는 주문번호 생성

--- a/src/main/java/co/kr/allpick/domain/product/entity/ProductOption.java
+++ b/src/main/java/co/kr/allpick/domain/product/entity/ProductOption.java
@@ -54,4 +54,8 @@ public class ProductOption extends BaseEntity{
         
         this.stockQuantity = restStock;
     }
+
+    public void restoreStock(int quantity) {
+        this.stockQuantity += quantity;
+    }
 }	

--- a/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
+++ b/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
@@ -61,6 +61,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/admin/sellers/**").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admin/products/*/approve").hasAuthority("ROLE_SUPER_ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/admin/products/*/reject").hasAuthority("ROLE_SUPER_ADMIN")
+                .requestMatchers(HttpMethod.PATCH, "/api/orders/*/cancel").hasAuthority("ROLE_USER")
                 .requestMatchers(HttpMethod.GET, "/api/faqs/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/faqs/**").hasAnyAuthority("ROLE_SUPER_ADMIN", "ROLE_CS_ADMIN")
                 .requestMatchers(HttpMethod.PUT, "/api/faqs/**").hasAnyAuthority("ROLE_SUPER_ADMIN", "ROLE_CS_ADMIN")

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 입력값입니다."),
     APPROVAL_NOT_PENDING(HttpStatus.BAD_REQUEST, "APPROVAL_NOT_PENDING", "승인 대기 상태의 항목만 처리할 수 있습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "주문을 찾을 수 없습니다."),
+    UNAUTHORIZED_ORDER(HttpStatus.FORBIDDEN, "UNAUTHORIZED_ORDER", "본인의 주문만 처리할 수 있습니다."),
+    ORDER_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_CANCEL", "주문 완료(PENDING) 상태에서만 취소할 수 있습니다."),
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_ITEM_NOT_FOUND", "주문 상품을 찾을 수 없습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "결제 정보를 찾을 수 없습니다."),
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS_NOT_FOUND", "배송지를 찾을 수 없습니다."),

--- a/src/test/java/co/kr/allpick/domain/order/service/impl/OrderServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/order/service/impl/OrderServiceImplTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.atLeastOnce;
 
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -39,6 +39,8 @@ import co.kr.allpick.domain.order.dto.OrderResponseDto;
 import co.kr.allpick.domain.order.dto.PaymentResponseDto;
 import co.kr.allpick.domain.order.entity.DeliveryAddress;
 import co.kr.allpick.domain.order.entity.Order;
+import co.kr.allpick.domain.order.entity.Order.OrderStatus;
+import co.kr.allpick.domain.order.entity.OrderItem;
 import co.kr.allpick.domain.order.entity.Payment;
 import co.kr.allpick.domain.order.repository.DeliveryAddressRepository;
 import co.kr.allpick.domain.order.repository.OrderItemRepository;
@@ -111,13 +113,13 @@ class OrderServiceImplTest {
         ReflectionTestUtils.setField(mockOrder, "orderNumber", "ORD-GENERATED-001");
         ReflectionTestUtils.setField(mockOrder, "orderItems", new ArrayList<>());
 
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
-        when(deliveryAddressRepository.findById(anyLong())).thenReturn(Optional.of(mockAddress));
-        when(orderRepository.existsByOrderNumber(anyString())).thenReturn(false);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(mockMember));
+        given(deliveryAddressRepository.findById(anyLong())).willReturn(Optional.of(mockAddress));
+        given(orderRepository.existsByOrderNumber(anyString())).willReturn(false);
         // 생성 시점과 금액 업데이트 후 시점 모두 mockOrder 반환
-        when(orderRepository.save(any(Order.class))).thenReturn(mockOrder);
-        when(productRepository.findById(100L)).thenReturn(Optional.of(mockProduct));
-        when(orderItemRepository.sumTotalPriceByOrderId(any())).thenReturn(BigDecimal.valueOf(20000));
+        given(orderRepository.save(any(Order.class))).willReturn(mockOrder);
+        given(productRepository.findById(100L)).willReturn(Optional.of(mockProduct));
+        given(orderItemRepository.sumTotalPriceByOrderId(any())).willReturn(BigDecimal.valueOf(20000));
 
         // when
         OrderResponseDto result = orderService.createOrder(memberId, request);
@@ -137,15 +139,15 @@ class OrderServiceImplTest {
         OrderItemRequestDto itemRequest = new OrderItemRequestDto(999L, 10L, 1);
         OrderCreateRequestDto request = new OrderCreateRequestDto(1L, null, List.of(itemRequest));
 
-        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
-        when(deliveryAddressRepository.findById(anyLong())).thenReturn(Optional.of(mockAddress));
-        when(orderRepository.save(any())).thenReturn(new Order()); // 예외 발생 방지용 Mock 반환
-        when(productRepository.findById(999L)).thenReturn(Optional.empty());
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(mockMember));
+        given(deliveryAddressRepository.findById(anyLong())).willReturn(Optional.of(mockAddress));
+        given(orderRepository.save(any())).willReturn(new Order()); // 예외 발생 방지용 Mock 반환
+        given(productRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> orderService.createOrder(memberId, request))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PRODUCT_NOT_FOUND);
     }
 
     @Test
@@ -160,8 +162,8 @@ class OrderServiceImplTest {
 
         DeliveryAddress addressToUpdate = spy(mockAddress);
 
-        when(deliveryAddressRepository.findById(addressId)).thenReturn(Optional.of(addressToUpdate));
-        when(orderRepository.existsByDeliveryAddress_AddressId(addressId)).thenReturn(false);
+        given(deliveryAddressRepository.findById(addressId)).willReturn(Optional.of(addressToUpdate));
+        given(orderRepository.existsByDeliveryAddress_AddressId(addressId)).willReturn(false);
 
         // when
         DeliveryAddressResponseDto result = orderService.updateDeliveryAddress(memberId, addressId, request);
@@ -179,13 +181,13 @@ class OrderServiceImplTest {
         Long memberId = 1L;
         Long addressId = 1L;
 
-        when(deliveryAddressRepository.findById(addressId)).thenReturn(Optional.of(mockAddress));
-        when(orderRepository.existsByDeliveryAddress_AddressId(addressId)).thenReturn(true);
+        given(deliveryAddressRepository.findById(addressId)).willReturn(Optional.of(mockAddress));
+        given(orderRepository.existsByDeliveryAddress_AddressId(addressId)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> orderService.deleteDeliveryAddress(memberId, addressId))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.ADDRESS_CANNOT_MODIFY.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADDRESS_CANNOT_MODIFY);
     }
 
     @Test
@@ -200,7 +202,7 @@ class OrderServiceImplTest {
                 .status(Payment.PaymentStatus.DONE)
                 .build();
 
-        when(paymentRepository.findByOrder_OrderId(orderId)).thenReturn(Optional.of(mockPayment));
+        given(paymentRepository.findByOrder_OrderId(orderId)).willReturn(Optional.of(mockPayment));
 
         // when
         PaymentResponseDto result = orderService.getPayment(orderId);
@@ -212,12 +214,103 @@ class OrderServiceImplTest {
     }
 
     @Test
+    @DisplayName("주문 취소 성공")
+    void 주문_취소_성공() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 1L;
+        Order order = spy(order(memberId, OrderStatus.PENDING));
+        ProductOption productOption = ProductOption.builder()
+                .optionName("색상")
+                .optionValue("블랙")
+                .stockQuantity(5)
+                .build();
+        Product product = Product.builder()
+                .productId(100L)
+                .productName("테스트 상품")
+                .build();
+        OrderItem orderItem = OrderItem.builder()
+                .product(product)
+                .productOption(productOption)
+                .productName("테스트 상품")
+                .productPrice(BigDecimal.valueOf(10000))
+                .quantity(2)
+                .totalPrice(BigDecimal.valueOf(20000))
+                .build();
+        order.addOrderItem(orderItem);
+
+        given(orderRepository.findByIdWithItems(orderId)).willReturn(Optional.of(order));
+
+        // when
+        OrderResponseDto result = orderService.cancelOrder(memberId, orderId);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(productOption.getStockQuantity()).isEqualTo(7);
+        verify(order).updateStatus(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("주문 취소 실패 - 주문이 존재하지 않음")
+    void 주문_취소_실패_주문없음() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 1L;
+
+        given(orderRepository.findByIdWithItems(orderId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.cancelOrder(memberId, orderId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("주문 취소 실패 - 본인 주문이 아님")
+    void 주문_취소_실패_본인주문아님() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 1L;
+        Order order = order(2L, OrderStatus.PENDING);
+
+        given(orderRepository.findByIdWithItems(orderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.cancelOrder(memberId, orderId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_ORDER);
+    }
+
+    @Test
+    @DisplayName("주문 취소 실패 - 취소 불가능한 상태")
+    void 주문_취소_실패_취소불가능상태() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 1L;
+        for (OrderStatus status : List.of(
+                OrderStatus.PAID,
+                OrderStatus.SHIPPING,
+                OrderStatus.DELIVERED,
+                OrderStatus.CANCELLED
+        )) {
+            Order order = order(memberId, status);
+
+            given(orderRepository.findByIdWithItems(orderId)).willReturn(Optional.of(order));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.cancelOrder(memberId, orderId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_CANNOT_CANCEL);
+        }
+    }
+
+    @Test
     @DisplayName("배송지 목록 조회 성공")
     void 배송지_목록_조회_성공() {
         // given
         Long memberId = 1L;
-        when(deliveryAddressRepository.findByMemberIdAndDeletedAtIsNull(memberId))
-            .thenReturn(List.of(mockAddress));
+        given(deliveryAddressRepository.findByMemberIdAndDeletedAtIsNull(memberId))
+            .willReturn(List.of(mockAddress));
 
         // when
         List<DeliveryAddressResponseDto> result = orderService.getDeliveryAddresses(memberId);
@@ -227,4 +320,24 @@ class OrderServiceImplTest {
         assertThat(result.get(0).getRecipientName()).isEqualTo("테스터");
         assertThat(result.get(0).getAddressId()).isEqualTo(1L);
     }
-}	
+
+    private Order order(Long memberId, OrderStatus status) {
+        Member member = new Member();
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        Order order = Order.builder()
+                .member(member)
+                .deliveryAddress(mockAddress)
+                .orderNumber("ORD-TEST-001")
+                .totalAmount(BigDecimal.valueOf(10000))
+                .discountAmount(BigDecimal.ZERO)
+                .shippingFee(3000)
+                .status(status)
+                .orderedAt(java.time.LocalDateTime.now())
+                .build();
+
+        ReflectionTestUtils.setField(order, "orderId", 1L);
+        ReflectionTestUtils.setField(order, "orderItems", new ArrayList<>());
+        return order;
+    }
+}


### PR DESCRIPTION
﻿## 개요
- 마이페이지 주문 내역에서 회원 본인 주문을 취소할 수 있는 백엔드 API를 구현했습니다.

---

## 작업 내용
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller: `PATCH /api/orders/{orderId}/cancel` 주문 취소 엔드포인트 추가
- Service: 본인 주문 검증, PENDING 상태 검증, 취소 시 재고 복구 후 CANCELLED 상태 변경
- Repository: 기존 `findByIdWithItems` 조회 흐름 사용
- 기타: `UNAUTHORIZED_ORDER`, `ORDER_CANNOT_CANCEL` ErrorCode 추가 및 주문취소 URL ROLE_USER 권한 매처 추가

---

## 관련 이슈
- 관련 이슈: 없음

---

## 변경 전 / 후
### Before
- 마이페이지 주문 내역의 주문 취소 버튼과 연결할 백엔드 API가 없었습니다.
- 주문 생성 시 차감된 상품 옵션 재고를 주문 취소 시 되돌리는 흐름이 없었습니다.

### After
- 로그인한 회원이 본인 주문만 취소할 수 있습니다.
- 주문 완료(PENDING) 상태에서만 취소할 수 있습니다.
- 주문 취소 시 주문 상품 수량만큼 상품 옵션 재고를 복구합니다.
- 관리자 토큰은 주문취소 API 권한 매처에서 차단됩니다.

---

## 검증
- `./gradlew.bat test --tests co.kr.allpick.domain.order.service.impl.OrderServiceImplTest`
- `git diff --check`

---

## 참고
- 주문 도메인에 주문취소 API와 재고 복구 로직이 추가되어 @gungang1212-tech 확인 부탁드립니다.
- 현재 판매자 로그인 토큰은 일반회원 JWT 구조를 같이 사용하고 있어, 판매자 토큰과 일반회원 토큰의 완전한 분리는 별도 인증 설계 이슈로 남아 있습니다.
