### PR TITLE
feat: add admin category api

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/category/controller/AdminCategoryController.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/controller/AdminCategoryController.java
@@ -1,0 +1,103 @@
+package co.kr.allpick.domain.admin.category.controller;
+
+import co.kr.allpick.domain.admin.category.controller.docs.AdminCategoryControllerDocs;
+import co.kr.allpick.domain.admin.category.dto.AdminCategoryRequestDto;
+import co.kr.allpick.domain.admin.category.service.AdminCategoryService;
+import co.kr.allpick.domain.product.dto.ChildCategoryResponseDto;
+import co.kr.allpick.domain.product.dto.ParentCategoryResponseDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/categories")
+public class AdminCategoryController implements AdminCategoryControllerDocs {
+
+    private final AdminCategoryService adminCategoryService;
+
+    @Override
+    @GetMapping("/parents")
+    public ResponseEntity<ApiResponse<List<ParentCategoryResponseDto>>> getParentCategories(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo) {
+        return ApiResponse.success("대분류 목록 조회 성공", adminCategoryService.getParentCategories(adminInfo));
+    }
+
+    @Override
+    @PostMapping("/parents")
+    public ResponseEntity<ApiResponse<ParentCategoryResponseDto>> createParentCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @RequestBody @Valid AdminCategoryRequestDto request) {
+        return ApiResponse.success("대분류 등록 성공", adminCategoryService.createParentCategory(adminInfo, request));
+    }
+
+    @Override
+    @PatchMapping("/parents/{parentCategoryId}")
+    public ResponseEntity<ApiResponse<ParentCategoryResponseDto>> updateParentCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId,
+            @RequestBody @Valid AdminCategoryRequestDto request) {
+        return ApiResponse.success("대분류 수정 성공",
+                adminCategoryService.updateParentCategory(adminInfo, parentCategoryId, request));
+    }
+
+    @Override
+    @DeleteMapping("/parents/{parentCategoryId}")
+    public ResponseEntity<ApiResponse<Void>> deleteParentCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId) {
+        adminCategoryService.deleteParentCategory(adminInfo, parentCategoryId);
+        return ApiResponse.success("대분류 삭제 성공");
+    }
+
+    @Override
+    @GetMapping("/parents/{parentCategoryId}/children")
+    public ResponseEntity<ApiResponse<List<ChildCategoryResponseDto>>> getChildCategories(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId) {
+        return ApiResponse.success("소분류 목록 조회 성공",
+                adminCategoryService.getChildCategories(adminInfo, parentCategoryId));
+    }
+
+    @Override
+    @PostMapping("/parents/{parentCategoryId}/children")
+    public ResponseEntity<ApiResponse<ChildCategoryResponseDto>> createChildCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId,
+            @RequestBody @Valid AdminCategoryRequestDto request) {
+        return ApiResponse.success("소분류 등록 성공",
+                adminCategoryService.createChildCategory(adminInfo, parentCategoryId, request));
+    }
+
+    @Override
+    @PatchMapping("/children/{childCategoryId}")
+    public ResponseEntity<ApiResponse<ChildCategoryResponseDto>> updateChildCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("childCategoryId") Long childCategoryId,
+            @RequestBody @Valid AdminCategoryRequestDto request) {
+        return ApiResponse.success("소분류 수정 성공",
+                adminCategoryService.updateChildCategory(adminInfo, childCategoryId, request));
+    }
+
+    @Override
+    @DeleteMapping("/children/{childCategoryId}")
+    public ResponseEntity<ApiResponse<Void>> deleteChildCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("childCategoryId") Long childCategoryId) {
+        adminCategoryService.deleteChildCategory(adminInfo, childCategoryId);
+        return ApiResponse.success("소분류 삭제 성공");
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/admin/category/controller/docs/AdminCategoryControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/controller/docs/AdminCategoryControllerDocs.java
@@ -1,0 +1,70 @@
+package co.kr.allpick.domain.admin.category.controller.docs;
+
+import co.kr.allpick.domain.admin.category.dto.AdminCategoryRequestDto;
+import co.kr.allpick.domain.product.dto.ChildCategoryResponseDto;
+import co.kr.allpick.domain.product.dto.ParentCategoryResponseDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Admin Category", description = "관리자 카테고리 관리 API")
+public interface AdminCategoryControllerDocs {
+
+    @Operation(summary = "대분류 목록 조회")
+    ResponseEntity<ApiResponse<List<ParentCategoryResponseDto>>> getParentCategories(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo
+    );
+
+    @Operation(summary = "대분류 등록")
+    ResponseEntity<ApiResponse<ParentCategoryResponseDto>> createParentCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @RequestBody @Valid AdminCategoryRequestDto request
+    );
+
+    @Operation(summary = "대분류 수정")
+    ResponseEntity<ApiResponse<ParentCategoryResponseDto>> updateParentCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId,
+            @RequestBody @Valid AdminCategoryRequestDto request
+    );
+
+    @Operation(summary = "대분류 삭제")
+    ResponseEntity<ApiResponse<Void>> deleteParentCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId
+    );
+
+    @Operation(summary = "소분류 목록 조회")
+    ResponseEntity<ApiResponse<List<ChildCategoryResponseDto>>> getChildCategories(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId
+    );
+
+    @Operation(summary = "소분류 등록")
+    ResponseEntity<ApiResponse<ChildCategoryResponseDto>> createChildCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("parentCategoryId") Long parentCategoryId,
+            @RequestBody @Valid AdminCategoryRequestDto request
+    );
+
+    @Operation(summary = "소분류 수정")
+    ResponseEntity<ApiResponse<ChildCategoryResponseDto>> updateChildCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("childCategoryId") Long childCategoryId,
+            @RequestBody @Valid AdminCategoryRequestDto request
+    );
+
+    @Operation(summary = "소분류 삭제")
+    ResponseEntity<ApiResponse<Void>> deleteChildCategory(
+            @AuthenticationPrincipal AdminJwtUserInfoDto adminInfo,
+            @PathVariable("childCategoryId") Long childCategoryId
+    );
+}

--- a/src/main/java/co/kr/allpick/domain/admin/category/dto/AdminCategoryRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/dto/AdminCategoryRequestDto.java
@@ -1,0 +1,38 @@
+package co.kr.allpick.domain.admin.category.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자 카테고리 요청 DTO")
+public class AdminCategoryRequestDto {
+
+    @NotBlank(message = "카테고리명은 필수입니다.")
+    @Schema(description = "카테고리명", example = "뷰티")
+    private String categoryName;
+
+    @NotBlank(message = "slug는 필수입니다.")
+    @Schema(description = "URL 식별자", example = "beauty")
+    private String slug;
+
+    @NotNull(message = "정렬 순서는 필수입니다.")
+    @Min(value = 0, message = "정렬 순서는 0 이상이어야 합니다.")
+    @Schema(description = "정렬 순서", example = "1")
+    private Integer sortOrder;
+
+    @NotNull(message = "노출 여부는 필수입니다.")
+    @Min(value = 0, message = "노출 여부는 0 또는 1이어야 합니다.")
+    @Max(value = 1, message = "노출 여부는 0 또는 1이어야 합니다.")
+    @Schema(description = "노출 여부", example = "1")
+    private Integer isActive;
+}

--- a/src/main/java/co/kr/allpick/domain/admin/category/service/AdminCategoryService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/service/AdminCategoryService.java
@@ -1,0 +1,39 @@
+package co.kr.allpick.domain.admin.category.service;
+
+import co.kr.allpick.domain.admin.category.dto.AdminCategoryRequestDto;
+import co.kr.allpick.domain.product.dto.ChildCategoryResponseDto;
+import co.kr.allpick.domain.product.dto.ParentCategoryResponseDto;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+
+import java.util.List;
+
+public interface AdminCategoryService {
+
+    List<ParentCategoryResponseDto> getParentCategories(AdminJwtUserInfoDto adminInfo);
+
+    ParentCategoryResponseDto createParentCategory(AdminJwtUserInfoDto adminInfo, AdminCategoryRequestDto request);
+
+    ParentCategoryResponseDto updateParentCategory(
+            AdminJwtUserInfoDto adminInfo,
+            Long parentCategoryId,
+            AdminCategoryRequestDto request
+    );
+
+    void deleteParentCategory(AdminJwtUserInfoDto adminInfo, Long parentCategoryId);
+
+    List<ChildCategoryResponseDto> getChildCategories(AdminJwtUserInfoDto adminInfo, Long parentCategoryId);
+
+    ChildCategoryResponseDto createChildCategory(
+            AdminJwtUserInfoDto adminInfo,
+            Long parentCategoryId,
+            AdminCategoryRequestDto request
+    );
+
+    ChildCategoryResponseDto updateChildCategory(
+            AdminJwtUserInfoDto adminInfo,
+            Long childCategoryId,
+            AdminCategoryRequestDto request
+    );
+
+    void deleteChildCategory(AdminJwtUserInfoDto adminInfo, Long childCategoryId);
+}

--- a/src/main/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImpl.java
@@ -1,0 +1,214 @@
+package co.kr.allpick.domain.admin.category.service.impl;
+
+import co.kr.allpick.domain.admin.category.dto.AdminCategoryRequestDto;
+import co.kr.allpick.domain.admin.category.service.AdminCategoryService;
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.domain.product.dto.ChildCategoryResponseDto;
+import co.kr.allpick.domain.product.dto.ParentCategoryResponseDto;
+import co.kr.allpick.domain.product.entity.ChildCategory;
+import co.kr.allpick.domain.product.entity.ParentCategory;
+import co.kr.allpick.domain.product.repository.ChildCategoryRepository;
+import co.kr.allpick.domain.product.repository.ParentCategoryRepository;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminCategoryServiceImpl implements AdminCategoryService {
+
+    private static final Logger logger = LogManager.getLogger(AdminCategoryServiceImpl.class);
+
+    private final AdminRepository adminRepository;
+    private final ParentCategoryRepository parentCategoryRepository;
+    private final ChildCategoryRepository childCategoryRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ParentCategoryResponseDto> getParentCategories(AdminJwtUserInfoDto adminInfo) {
+        Admin admin = getSuperAdmin(adminInfo);
+        logger.info("[AdminCategoryServiceImpl] 대분류 목록 조회 - actorAdminId: {}", admin.getAdminId());
+
+        return parentCategoryRepository.findAllByDeletedAtIsNullOrderBySortOrderAsc()
+                .stream()
+                .map(ParentCategoryResponseDto::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public ParentCategoryResponseDto createParentCategory(AdminJwtUserInfoDto adminInfo, AdminCategoryRequestDto request) {
+        Admin admin = getSuperAdmin(adminInfo);
+        validateSlugForCreate(request.getSlug());
+
+        ParentCategory parentCategory = parentCategoryRepository.save(ParentCategory.builder()
+                .categoryName(request.getCategoryName().trim())
+                .slug(request.getSlug().trim())
+                .sortOrder(request.getSortOrder())
+                .isActive(request.getIsActive())
+                .build());
+
+        logger.info("[AdminCategoryServiceImpl] 대분류 등록 완료 - actorAdminId: {}, parentCategoryId: {}",
+                admin.getAdminId(), parentCategory.getParentCategoryId());
+        return ParentCategoryResponseDto.from(parentCategory);
+    }
+
+    @Override
+    @Transactional
+    public ParentCategoryResponseDto updateParentCategory(
+            AdminJwtUserInfoDto adminInfo,
+            Long parentCategoryId,
+            AdminCategoryRequestDto request
+    ) {
+        Admin admin = getSuperAdmin(adminInfo);
+        ParentCategory parentCategory = getParentCategory(parentCategoryId);
+        validateSlugForUpdate(request.getSlug(), parentCategory.getSlug());
+
+        parentCategory.update(
+                request.getCategoryName().trim(),
+                request.getSlug().trim(),
+                request.getSortOrder(),
+                request.getIsActive()
+        );
+
+        logger.info("[AdminCategoryServiceImpl] 대분류 수정 완료 - actorAdminId: {}, parentCategoryId: {}",
+                admin.getAdminId(), parentCategoryId);
+        return ParentCategoryResponseDto.from(parentCategory);
+    }
+
+    @Override
+    @Transactional
+    public void deleteParentCategory(AdminJwtUserInfoDto adminInfo, Long parentCategoryId) {
+        Admin admin = getSuperAdmin(adminInfo);
+        ParentCategory parentCategory = getParentCategory(parentCategoryId);
+        parentCategory.deactivate();
+
+        logger.info("[AdminCategoryServiceImpl] 대분류 비활성화 완료 - actorAdminId: {}, parentCategoryId: {}",
+                admin.getAdminId(), parentCategoryId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChildCategoryResponseDto> getChildCategories(AdminJwtUserInfoDto adminInfo, Long parentCategoryId) {
+        Admin admin = getSuperAdmin(adminInfo);
+        getParentCategory(parentCategoryId);
+        logger.info("[AdminCategoryServiceImpl] 소분류 목록 조회 - actorAdminId: {}, parentCategoryId: {}",
+                admin.getAdminId(), parentCategoryId);
+
+        return childCategoryRepository
+                .findByParentCategory_ParentCategoryIdAndDeletedAtIsNullOrderBySortOrderAsc(parentCategoryId)
+                .stream()
+                .map(ChildCategoryResponseDto::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public ChildCategoryResponseDto createChildCategory(
+            AdminJwtUserInfoDto adminInfo,
+            Long parentCategoryId,
+            AdminCategoryRequestDto request
+    ) {
+        Admin admin = getSuperAdmin(adminInfo);
+        ParentCategory parentCategory = getParentCategory(parentCategoryId);
+        validateSlugForCreate(request.getSlug());
+
+        ChildCategory childCategory = childCategoryRepository.save(ChildCategory.builder()
+                .parentCategory(parentCategory)
+                .categoryName(request.getCategoryName().trim())
+                .slug(request.getSlug().trim())
+                .sortOrder(request.getSortOrder())
+                .isActive(request.getIsActive())
+                .build());
+
+        logger.info("[AdminCategoryServiceImpl] 소분류 등록 완료 - actorAdminId: {}, parentCategoryId: {}, childCategoryId: {}",
+                admin.getAdminId(), parentCategoryId, childCategory.getChildCategoryId());
+        return ChildCategoryResponseDto.from(childCategory);
+    }
+
+    @Override
+    @Transactional
+    public ChildCategoryResponseDto updateChildCategory(
+            AdminJwtUserInfoDto adminInfo,
+            Long childCategoryId,
+            AdminCategoryRequestDto request
+    ) {
+        Admin admin = getSuperAdmin(adminInfo);
+        ChildCategory childCategory = getChildCategory(childCategoryId);
+        ParentCategory parentCategory = childCategory.getParentCategory();
+        validateSlugForUpdate(request.getSlug(), childCategory.getSlug());
+
+        childCategory.update(
+                parentCategory,
+                request.getCategoryName().trim(),
+                request.getSlug().trim(),
+                request.getSortOrder(),
+                request.getIsActive()
+        );
+
+        logger.info("[AdminCategoryServiceImpl] 소분류 수정 완료 - actorAdminId: {}, childCategoryId: {}",
+                admin.getAdminId(), childCategoryId);
+        return ChildCategoryResponseDto.from(childCategory);
+    }
+
+    @Override
+    @Transactional
+    public void deleteChildCategory(AdminJwtUserInfoDto adminInfo, Long childCategoryId) {
+        Admin admin = getSuperAdmin(adminInfo);
+        ChildCategory childCategory = getChildCategory(childCategoryId);
+        childCategory.deactivate();
+
+        logger.info("[AdminCategoryServiceImpl] 소분류 비활성화 완료 - actorAdminId: {}, childCategoryId: {}",
+                admin.getAdminId(), childCategoryId);
+    }
+
+    private Admin getSuperAdmin(AdminJwtUserInfoDto adminInfo) {
+        if (adminInfo == null || adminInfo.getRole() != Admin.AdminRole.SUPER_ADMIN) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+
+        Admin admin = adminRepository.findById(adminInfo.getAdminId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (admin.getRole() != Admin.AdminRole.SUPER_ADMIN || admin.getStatus() != Admin.AdminStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+        return admin;
+    }
+
+    private ParentCategory getParentCategory(Long parentCategoryId) {
+        return parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(parentCategoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    private ChildCategory getChildCategory(Long childCategoryId) {
+        return childCategoryRepository.findByChildCategoryIdAndDeletedAtIsNull(childCategoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    private void validateSlugForCreate(String slug) {
+        if (isSlugDuplicated(slug)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validateSlugForUpdate(String requestSlug, String currentSlug) {
+        String trimmedSlug = requestSlug.trim();
+        if (!trimmedSlug.equals(currentSlug) && isSlugDuplicated(trimmedSlug)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private boolean isSlugDuplicated(String slug) {
+        return parentCategoryRepository.existsBySlugAndDeletedAtIsNull(slug.trim())
+                || childCategoryRepository.existsBySlugAndDeletedAtIsNull(slug.trim());
+    }
+}

--- a/src/main/java/co/kr/allpick/domain/product/entity/ChildCategory.java
+++ b/src/main/java/co/kr/allpick/domain/product/entity/ChildCategory.java
@@ -45,4 +45,17 @@ public class ChildCategory extends BaseEntity {
 
     @Column(name = "slug", length = 100, nullable = false, unique = true)
     private String slug;
+
+    public void update(ParentCategory parentCategory, String categoryName, String slug, Integer sortOrder, Integer isActive) {
+        this.parentCategory = parentCategory;
+        this.categoryName = categoryName;
+        this.slug = slug;
+        this.sortOrder = sortOrder;
+        this.isActive = isActive;
+    }
+
+    public void deactivate() {
+        this.isActive = 0;
+        delete();
+    }
 }

--- a/src/main/java/co/kr/allpick/domain/product/entity/ParentCategory.java
+++ b/src/main/java/co/kr/allpick/domain/product/entity/ParentCategory.java
@@ -37,6 +37,17 @@ public class ParentCategory extends BaseEntity{
 		
 	@Column(name = "slug", length = 100, nullable = false, unique = true)
 	private String slug;	// URL 식별자	
+
+	public void update(String categoryName, String slug, Integer sortOrder, Integer isActive) {
+		this.categoryName = categoryName;
+		this.slug = slug;
+		this.sortOrder = sortOrder;
+		this.isActive = isActive;
+	}
+
+	public void deactivate() {
+		this.isActive = 0;
+		delete();
+	}
 	
 }
- 

--- a/src/main/java/co/kr/allpick/domain/product/repository/ChildCategoryRepository.java
+++ b/src/main/java/co/kr/allpick/domain/product/repository/ChildCategoryRepository.java
@@ -14,6 +14,18 @@ public interface ChildCategoryRepository extends JpaRepository<ChildCategory, Lo
     List<ChildCategory> findByParentCategory_ParentCategoryIdAndIsActiveOrderBySortOrderAsc(
             Long parentCategoryId, Integer isActive);
 
+    List<ChildCategory> findByParentCategory_ParentCategoryIdAndIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(
+            Long parentCategoryId, Integer isActive);
+
+    List<ChildCategory> findByParentCategory_ParentCategoryIdAndDeletedAtIsNullOrderBySortOrderAsc(
+            Long parentCategoryId);
+
     // slug로 단건 조회
     Optional<ChildCategory> findBySlug(String slug);
+
+    Optional<ChildCategory> findBySlugAndIsActiveAndDeletedAtIsNull(String slug, Integer isActive);
+
+    Optional<ChildCategory> findByChildCategoryIdAndDeletedAtIsNull(Long childCategoryId);
+
+    boolean existsBySlugAndDeletedAtIsNull(String slug);
 }

--- a/src/main/java/co/kr/allpick/domain/product/repository/ParentCategoryRepository.java
+++ b/src/main/java/co/kr/allpick/domain/product/repository/ParentCategoryRepository.java
@@ -14,7 +14,17 @@ public interface ParentCategoryRepository extends JpaRepository<ParentCategory, 
     // 노출 중인 카테고리만 정렬 순서대로 조회
     List<ParentCategory> findByIsActiveOrderBySortOrderAsc(Integer isActive);
 
+    List<ParentCategory> findByIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(Integer isActive);
+
+    List<ParentCategory> findAllByDeletedAtIsNullOrderBySortOrderAsc();
+
     // slug로 단건 조회
     Optional<ParentCategory> findBySlug(String slug);
+
+    Optional<ParentCategory> findBySlugAndIsActiveAndDeletedAtIsNull(String slug, Integer isActive);
+
+    Optional<ParentCategory> findByParentCategoryIdAndDeletedAtIsNull(Long parentCategoryId);
+
+    boolean existsBySlugAndDeletedAtIsNull(String slug);
 
 }

--- a/src/main/java/co/kr/allpick/domain/product/service/impl/ChildCategoryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/product/service/impl/ChildCategoryServiceImpl.java
@@ -29,7 +29,7 @@ public class ChildCategoryServiceImpl implements ChildCategoryService {
     public List<ChildCategoryResponseDto> getActiveChildCategories(Long parentCategoryId) {
         logger.info("노출 중인 자식 카테고리 조회 - parentCategoryId: {}", parentCategoryId);
         return childCategoryRepository
-                .findByParentCategory_ParentCategoryIdAndIsActiveOrderBySortOrderAsc(parentCategoryId, ACTIVE)
+                .findByParentCategory_ParentCategoryIdAndIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(parentCategoryId, ACTIVE)
                 .stream()
                 .map(ChildCategoryResponseDto::from)
                 .collect(Collectors.toList());
@@ -39,7 +39,7 @@ public class ChildCategoryServiceImpl implements ChildCategoryService {
     @Transactional(readOnly = true)
     public ChildCategoryResponseDto getChildCategoryBySlug(String slug) {
         logger.info("slug로 자식 카테고리 조회 - slug: {}", slug);
-        ChildCategory childCategory = childCategoryRepository.findBySlug(slug)
+        ChildCategory childCategory = childCategoryRepository.findBySlugAndIsActiveAndDeletedAtIsNull(slug, ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
         return ChildCategoryResponseDto.from(childCategory);
     }

--- a/src/main/java/co/kr/allpick/domain/product/service/impl/ParentCategoryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/product/service/impl/ParentCategoryServiceImpl.java
@@ -28,7 +28,7 @@ public class ParentCategoryServiceImpl implements ParentCategoryService {
     @Transactional(readOnly = true)
     public List<ParentCategoryResponseDto> getActiveParentCategories() {
         logger.info("노출 중인 부모 카테고리 전체 조회");
-        return parentCategoryRepository.findByIsActiveOrderBySortOrderAsc(ACTIVE)
+        return parentCategoryRepository.findByIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(ACTIVE)
                 .stream()
                 .map(ParentCategoryResponseDto::from)
                 .collect(Collectors.toList());
@@ -38,7 +38,7 @@ public class ParentCategoryServiceImpl implements ParentCategoryService {
     @Transactional(readOnly = true)
     public ParentCategoryResponseDto getParentCategoryBySlug(String slug) {
         logger.info("slug로 부모 카테고리 조회 - slug: {}", slug);
-        ParentCategory parentCategory = parentCategoryRepository.findBySlug(slug)
+        ParentCategory parentCategory = parentCategoryRepository.findBySlugAndIsActiveAndDeletedAtIsNull(slug, ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
         return ParentCategoryResponseDto.from(parentCategory);
     }

--- a/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
+++ b/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
@@ -61,6 +61,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/admins").hasAuthority("ROLE_SUPER_ADMIN")
                         .requestMatchers(HttpMethod.PATCH, "/api/admins/*/status").hasAuthority("ROLE_SUPER_ADMIN")
+                        .requestMatchers("/api/admin/categories/**").hasAuthority("ROLE_SUPER_ADMIN")
                         .requestMatchers("/api/admin/members/**").hasAuthority("ROLE_SUPER_ADMIN")
                         .requestMatchers("/api/admin/sellers/**").hasAuthority("ROLE_SUPER_ADMIN")
                         .requestMatchers("/api/admin/orders/**").hasAuthority("ROLE_SUPER_ADMIN")

--- a/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
@@ -1,0 +1,390 @@
+package co.kr.allpick.domain.admin.category.service.impl;
+
+import co.kr.allpick.domain.admin.category.dto.AdminCategoryRequestDto;
+import co.kr.allpick.domain.admin.entity.Admin;
+import co.kr.allpick.domain.admin.repository.AdminRepository;
+import co.kr.allpick.domain.product.dto.ChildCategoryResponseDto;
+import co.kr.allpick.domain.product.dto.ParentCategoryResponseDto;
+import co.kr.allpick.domain.product.entity.ChildCategory;
+import co.kr.allpick.domain.product.entity.ParentCategory;
+import co.kr.allpick.domain.product.repository.ChildCategoryRepository;
+import co.kr.allpick.domain.product.repository.ParentCategoryRepository;
+import co.kr.allpick.global.config.AdminJwtUserInfoDto;
+import co.kr.allpick.global.exception.BusinessException;
+import co.kr.allpick.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminCategoryServiceImplTest {
+
+    @Mock
+    AdminRepository adminRepository;
+
+    @Mock
+    ParentCategoryRepository parentCategoryRepository;
+
+    @Mock
+    ChildCategoryRepository childCategoryRepository;
+
+    @InjectMocks
+    AdminCategoryServiceImpl adminCategoryService;
+
+    @Test
+    @DisplayName("대분류 목록 조회 성공")
+    void 대분류_목록_조회_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory beauty = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        ParentCategory fashion = parentCategory(2L, "패션", "fashion", 2, 0);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findAllByDeletedAtIsNullOrderBySortOrderAsc())
+                .willReturn(List.of(beauty, fashion));
+
+        // when
+        List<ParentCategoryResponseDto> result = adminCategoryService.getParentCategories(adminInfo);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getCategoryName()).isEqualTo("뷰티");
+        assertThat(result.get(1).getIsActive()).isZero();
+    }
+
+    @Test
+    @DisplayName("대분류 등록 성공")
+    void 대분류_등록_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        AdminCategoryRequestDto request = request("뷰티", "beauty", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty")).willReturn(false);
+        given(parentCategoryRepository.save(any(ParentCategory.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ParentCategoryResponseDto result = adminCategoryService.createParentCategory(adminInfo, request);
+
+        // then
+        assertThat(result.getCategoryName()).isEqualTo("뷰티");
+        assertThat(result.getSlug()).isEqualTo("beauty");
+
+        ArgumentCaptor<ParentCategory> captor = ArgumentCaptor.forClass(ParentCategory.class);
+        verify(parentCategoryRepository).save(captor.capture());
+        assertThat(captor.getValue().getCategoryName()).isEqualTo("뷰티");
+        assertThat(captor.getValue().getSlug()).isEqualTo("beauty");
+        assertThat(captor.getValue().getSortOrder()).isEqualTo(1);
+        assertThat(captor.getValue().getIsActive()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("대분류 등록 실패 - slug 중복")
+    void 대분류_등록_실패_slug중복() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        AdminCategoryRequestDto request = request("뷰티", "beauty", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.createParentCategory(adminInfo, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+        verify(parentCategoryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("대분류 수정 성공")
+    void 대분류_수정_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        AdminCategoryRequestDto request = request("뷰티관", "beauty-zone", 2, 0);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty-zone")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty-zone")).willReturn(false);
+
+        // when
+        ParentCategoryResponseDto result = adminCategoryService.updateParentCategory(adminInfo, 1L, request);
+
+        // then
+        assertThat(result.getCategoryName()).isEqualTo("뷰티관");
+        assertThat(parentCategory.getSlug()).isEqualTo("beauty-zone");
+        assertThat(parentCategory.getSortOrder()).isEqualTo(2);
+        assertThat(parentCategory.getIsActive()).isZero();
+    }
+
+    @Test
+    @DisplayName("대분류 삭제 성공 - soft delete")
+    void 대분류_삭제_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+
+        // when
+        adminCategoryService.deleteParentCategory(adminInfo, 1L);
+
+        // then
+        assertThat(parentCategory.getIsActive()).isZero();
+        assertThat(parentCategory.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("소분류 등록 성공")
+    void 소분류_등록_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        AdminCategoryRequestDto request = request("스킨케어", "skincare", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("skincare")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("skincare")).willReturn(false);
+        given(childCategoryRepository.save(any(ChildCategory.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ChildCategoryResponseDto result = adminCategoryService.createChildCategory(adminInfo, 1L, request);
+
+        // then
+        assertThat(result.getCategoryName()).isEqualTo("스킨케어");
+
+        ArgumentCaptor<ChildCategory> captor = ArgumentCaptor.forClass(ChildCategory.class);
+        verify(childCategoryRepository).save(captor.capture());
+        assertThat(captor.getValue().getParentCategory()).isEqualTo(parentCategory);
+        assertThat(captor.getValue().getCategoryName()).isEqualTo("스킨케어");
+        assertThat(captor.getValue().getSlug()).isEqualTo("skincare");
+    }
+
+    @Test
+    @DisplayName("소분류 등록 실패 - 부모 카테고리 없음")
+    void 소분류_등록_실패_부모카테고리없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        AdminCategoryRequestDto request = request("스킨케어", "skincare", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.createChildCategory(adminInfo, 999L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_NOT_FOUND);
+        verify(childCategoryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("소분류 수정 성공")
+    void 소분류_수정_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        ChildCategory childCategory = childCategory(1L, parentCategory, "스킨케어", "skincare", 1, 1);
+        AdminCategoryRequestDto request = request("기초화장품", "basic-cosmetic", 2, 0);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(childCategoryRepository.findByChildCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(childCategory));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("basic-cosmetic")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("basic-cosmetic")).willReturn(false);
+
+        // when
+        ChildCategoryResponseDto result = adminCategoryService.updateChildCategory(adminInfo, 1L, request);
+
+        // then
+        assertThat(result.getCategoryName()).isEqualTo("기초화장품");
+        assertThat(childCategory.getParentCategory()).isEqualTo(parentCategory);
+        assertThat(childCategory.getSlug()).isEqualTo("basic-cosmetic");
+        assertThat(childCategory.getIsActive()).isZero();
+    }
+
+    @Test
+    @DisplayName("소분류 삭제 실패 - 카테고리 없음")
+    void 소분류_삭제_실패_카테고리없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(childCategoryRepository.findByChildCategoryIdAndDeletedAtIsNull(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.deleteChildCategory(adminInfo, 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("카테고리 관리 실패 - 인증 관리자 정보 없음")
+    void 카테고리_관리_실패_관리자정보없음() {
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.getParentCategories(null))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(parentCategoryRepository, never()).findAllByDeletedAtIsNullOrderBySortOrderAsc();
+    }
+
+    @Test
+    @DisplayName("카테고리 관리 실패 - JWT 권한 없음")
+    void 카테고리_관리_실패_JWT권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = csAdminInfo();
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.createParentCategory(adminInfo, request("뷰티", "beauty", 1, 1)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(parentCategoryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("카테고리 관리 실패 - 관리자 없음")
+    void 카테고리_관리_실패_관리자없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.getParentCategories(adminInfo))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_NOT_FOUND);
+        verify(parentCategoryRepository, never()).findAllByDeletedAtIsNullOrderBySortOrderAsc();
+    }
+
+    @Test
+    @DisplayName("카테고리 관리 실패 - DB 기준 관리자 권한 없음")
+    void 카테고리_관리_실패_DB관리자권한없음() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(csAdmin()));
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.getParentCategories(adminInfo))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(parentCategoryRepository, never()).findAllByDeletedAtIsNullOrderBySortOrderAsc();
+    }
+
+    @Test
+    @DisplayName("카테고리 관리 실패 - 관리자 BLOCKED")
+    void 카테고리_관리_실패_관리자BLOCKED() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        Admin blockedAdmin = Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.BLOCKED)
+                .build();
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(blockedAdmin));
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.getParentCategories(adminInfo))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
+        verify(parentCategoryRepository, never()).findAllByDeletedAtIsNullOrderBySortOrderAsc();
+    }
+
+    private AdminCategoryRequestDto request(String categoryName, String slug, Integer sortOrder, Integer isActive) {
+        return AdminCategoryRequestDto.builder()
+                .categoryName(categoryName)
+                .slug(slug)
+                .sortOrder(sortOrder)
+                .isActive(isActive)
+                .build();
+    }
+
+    private AdminJwtUserInfoDto superAdminInfo() {
+        return AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .build();
+    }
+
+    private AdminJwtUserInfoDto csAdminInfo() {
+        return AdminJwtUserInfoDto.builder()
+                .adminId(1L)
+                .role(Admin.AdminRole.CS_ADMIN)
+                .build();
+    }
+
+    private Admin superAdmin() {
+        return Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.SUPER_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+    }
+
+    private Admin csAdmin() {
+        return Admin.builder()
+                .email("admin@example.com")
+                .password("encodedPassword")
+                .adminName("관리자")
+                .adminPhone("010-0000-0000")
+                .role(Admin.AdminRole.CS_ADMIN)
+                .status(Admin.AdminStatus.ACTIVE)
+                .build();
+    }
+
+    private ParentCategory parentCategory(Long id, String categoryName, String slug, Integer sortOrder, Integer isActive) {
+        return ParentCategory.builder()
+                .parentCategoryId(id)
+                .categoryName(categoryName)
+                .slug(slug)
+                .sortOrder(sortOrder)
+                .isActive(isActive)
+                .build();
+    }
+
+    private ChildCategory childCategory(
+            Long id,
+            ParentCategory parentCategory,
+            String categoryName,
+            String slug,
+            Integer sortOrder,
+            Integer isActive
+    ) {
+        return ChildCategory.builder()
+                .childCategoryId(id)
+                .parentCategory(parentCategory)
+                .categoryName(categoryName)
+                .slug(slug)
+                .sortOrder(sortOrder)
+                .isActive(isActive)
+                .build();
+    }
+}

--- a/src/test/java/co/kr/allpick/domain/product/service/impl/ChildCategoryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/product/service/impl/ChildCategoryServiceImplTest.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class ChildCategoryServiceImplTest {
@@ -58,9 +58,9 @@ class ChildCategoryServiceImplTest {
                 .slug("makeup")
                 .build();
 
-        when(childCategoryRepository
-                .findByParentCategory_ParentCategoryIdAndIsActiveOrderBySortOrderAsc(parentCategoryId, 1))
-                .thenReturn(List.of(child1, child2));
+        given(childCategoryRepository
+                .findByParentCategory_ParentCategoryIdAndIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(parentCategoryId, 1))
+                .willReturn(List.of(child1, child2));
 
         // when
         List<ChildCategoryResponseDto> result = childCategoryService.getActiveChildCategories(parentCategoryId);
@@ -80,9 +80,9 @@ class ChildCategoryServiceImplTest {
         // given
         Long parentCategoryId = 99L;
 
-        when(childCategoryRepository
-                .findByParentCategory_ParentCategoryIdAndIsActiveOrderBySortOrderAsc(parentCategoryId, 1))
-                .thenReturn(List.of());
+        given(childCategoryRepository
+                .findByParentCategory_ParentCategoryIdAndIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(parentCategoryId, 1))
+                .willReturn(List.of());
 
         // when
         List<ChildCategoryResponseDto> result = childCategoryService.getActiveChildCategories(parentCategoryId);
@@ -111,8 +111,8 @@ class ChildCategoryServiceImplTest {
                 .slug("skincare")
                 .build();
 
-        when(childCategoryRepository.findBySlug("skincare"))
-                .thenReturn(Optional.of(childCategory));
+        given(childCategoryRepository.findBySlugAndIsActiveAndDeletedAtIsNull("skincare", 1))
+                .willReturn(Optional.of(childCategory));
 
         // when
         ChildCategoryResponseDto result = childCategoryService.getChildCategoryBySlug("skincare");
@@ -127,12 +127,12 @@ class ChildCategoryServiceImplTest {
     @DisplayName("slug로 자식 카테고리 단건 조회 실패 - 존재하지 않는 slug")
     void slug로_자식_카테고리_단건_조회_실패() {
         // given
-        when(childCategoryRepository.findBySlug("없는slug"))
-                .thenReturn(Optional.empty());
+        given(childCategoryRepository.findBySlugAndIsActiveAndDeletedAtIsNull("없는slug", 1))
+                .willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> childCategoryService.getChildCategoryBySlug("없는slug"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.CATEGORY_NOT_FOUND.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_NOT_FOUND);
     }
 }

--- a/src/test/java/co/kr/allpick/domain/product/service/impl/ParentCategoryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/product/service/impl/ParentCategoryServiceImplTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class ParentCategoryServiceImplTest {
@@ -46,8 +46,8 @@ class ParentCategoryServiceImplTest {
                 .slug("fashion")
                 .build();
 
-        when(parentCategoryRepository.findByIsActiveOrderBySortOrderAsc(1))
-                .thenReturn(List.of(category1, category2));
+        given(parentCategoryRepository.findByIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(1))
+                .willReturn(List.of(category1, category2));
 
         // when
         List<ParentCategoryResponseDto> result = parentCategoryService.getActiveParentCategories();
@@ -65,8 +65,8 @@ class ParentCategoryServiceImplTest {
     @DisplayName("노출 중인 부모 카테고리 없음")
     void 노출_중인_부모_카테고리_없음() {
         // given
-        when(parentCategoryRepository.findByIsActiveOrderBySortOrderAsc(1))
-                .thenReturn(List.of());
+        given(parentCategoryRepository.findByIsActiveAndDeletedAtIsNullOrderBySortOrderAsc(1))
+                .willReturn(List.of());
 
         // when
         List<ParentCategoryResponseDto> result = parentCategoryService.getActiveParentCategories();
@@ -87,8 +87,8 @@ class ParentCategoryServiceImplTest {
                 .slug("beauty")
                 .build();
 
-        when(parentCategoryRepository.findBySlug("beauty"))
-                .thenReturn(Optional.of(category));
+        given(parentCategoryRepository.findBySlugAndIsActiveAndDeletedAtIsNull("beauty", 1))
+                .willReturn(Optional.of(category));
 
         // when
         ParentCategoryResponseDto result = parentCategoryService.getParentCategoryBySlug("beauty");
@@ -103,12 +103,12 @@ class ParentCategoryServiceImplTest {
     @DisplayName("slug로 부모 카테고리 단건 조회 실패 - 존재하지 않는 slug")
     void slug로_부모_카테고리_단건_조회_실패() {
         // given
-        when(parentCategoryRepository.findBySlug("없는slug"))
-                .thenReturn(Optional.empty());
+        given(parentCategoryRepository.findBySlugAndIsActiveAndDeletedAtIsNull("없는slug", 1))
+                .willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> parentCategoryService.getParentCategoryBySlug("없는slug"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.CATEGORY_NOT_FOUND.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_NOT_FOUND);
     }
 }


### PR DESCRIPTION
﻿## 개요
- 관리자 카테고리 등록/수정/삭제 API 구현

---

## 작업 내용
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller:
  - `/api/admin/categories/**` 관리자 카테고리 관리 API 추가
  - 대분류/소분류 목록 조회, 등록, 수정, 삭제 지원
- Service:
  - SUPER_ADMIN + ACTIVE 관리자 검증 추가
  - 대분류/소분류 생성, 수정, soft delete 처리
  - slug 중복 검증 추가
- Repository:
  - 삭제되지 않은 카테고리 조회 메서드 추가
  - 관리자 목록/상세 조회용 메서드 추가
- 기타:
  - `ParentCategory`, `ChildCategory`에 setter 대신 변경 메서드 추가
  - 공개 카테고리 조회에서 삭제/비활성 카테고리 제외
  - `/api/admin/categories/**` SUPER_ADMIN 권한 매처 추가
  - 관리자 카테고리 서비스 테스트 추가

---

## 관련 이슈
- 관련 이슈: 카테고리 하드코딩 제거 및 관리자 카테고리 관리 기능 추가

---

## 변경 전 / 후
### Before
- 관리자 카테고리 관리 화면은 있었지만 백엔드 CRUD API가 없었습니다.
- 카테고리 관리를 DB 기반으로 처리할 수 없어 프론트에서 mock/하드코딩에 의존했습니다.
- 공개 카테고리 slug 조회에서 삭제/비활성 카테고리를 거르지 못했습니다.

### After
- 기존 `parent_categories`, `child_categories` 테이블 기준으로 관리자 카테고리 CRUD API를 추가했습니다.
- 관리자 권한은 `ROLE_SUPER_ADMIN`으로 제한했습니다.
- 카테고리 삭제는 물리 삭제가 아니라 `isActive = 0` + `deletedAt` 기반 soft delete로 처리했습니다.
- 공개 카테고리 조회는 삭제되지 않고 활성화된 카테고리만 반환하도록 보완했습니다.

---

## 테스트
- [x] `./gradlew.bat compileJava`
- [x] `./gradlew.bat test --tests "co.kr.allpick.domain.admin.category.service.impl.AdminCategoryServiceImplTest" --tests "co.kr.allpick.domain.product.service.impl.ParentCategoryServiceImplTest" --tests "co.kr.allpick.domain.product.service.impl.ChildCategoryServiceImplTest"`

### 참고
- 전체 `./gradlew.bat test`는 기존 테스트 실패가 남아 있습니다.
  - `AllPickApplicationTests` DB 연결 문제
  - 기존 `AuthServiceImplTest`
  - 기존 `CartServiceImplTest`
  - 기존 `SellerApplyServiceImplTest`
