### PR TITLE
fix: 카테고리 soft-delete 후 동일 slug 재등록 500 에러 해결

### DIFF
--- a/src/main/java/co/kr/allpick/domain/product/entity/ChildCategory.java
+++ b/src/main/java/co/kr/allpick/domain/product/entity/ChildCategory.java
@@ -54,8 +54,22 @@ public class ChildCategory extends BaseEntity {
         this.isActive = isActive;
     }
 
+    private static final String DELETED_SLUG_MARKER = "_deleted_";
+    private static final int SLUG_MAX_LENGTH = 100;
+
     public void deactivate() {
+        if (this.getDeletedAt() != null) return;
         this.isActive = 0;
+        this.slug = generateDeletedSlug(this.slug);
         delete();
+    }
+
+    private String generateDeletedSlug(String originalSlug) {
+        String marker = DELETED_SLUG_MARKER + this.childCategoryId + "_" + System.currentTimeMillis();
+        int maxOriginalLength = SLUG_MAX_LENGTH - marker.length();
+        String truncated = originalSlug.length() > maxOriginalLength
+                ? originalSlug.substring(0, maxOriginalLength)
+                : originalSlug;
+        return truncated + marker;
     }
 }

--- a/src/main/java/co/kr/allpick/domain/product/entity/ParentCategory.java
+++ b/src/main/java/co/kr/allpick/domain/product/entity/ParentCategory.java
@@ -45,9 +45,23 @@ public class ParentCategory extends BaseEntity{
 		this.isActive = isActive;
 	}
 
+	private static final String DELETED_SLUG_MARKER = "_deleted_";
+	private static final int SLUG_MAX_LENGTH = 100;
+
 	public void deactivate() {
+		if (this.getDeletedAt() != null) return;
 		this.isActive = 0;
+		this.slug = generateDeletedSlug(this.slug);
 		delete();
 	}
-	
+
+	private String generateDeletedSlug(String originalSlug) {
+		String marker = DELETED_SLUG_MARKER + this.parentCategoryId + "_" + System.currentTimeMillis();
+		int maxOriginalLength = SLUG_MAX_LENGTH - marker.length();
+		String truncated = originalSlug.length() > maxOriginalLength
+				? originalSlug.substring(0, maxOriginalLength)
+				: originalSlug;
+		return truncated + marker;
+	}
+
 }

--- a/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
@@ -152,6 +152,97 @@ class AdminCategoryServiceImplTest {
         // then
         assertThat(parentCategory.getIsActive()).isZero();
         assertThat(parentCategory.getDeletedAt()).isNotNull();
+        assertThat(parentCategory.getSlug()).matches("beauty_deleted_\\d+_\\d+");
+    }
+
+    @Test
+    @DisplayName("대분류 삭제 시 slug가 _deleted_ 마커 형태로 변경된다")
+    void 대분류_삭제_시_slug가_deleted_마커로_변경된다() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+
+        // when
+        adminCategoryService.deleteParentCategory(adminInfo, 1L);
+
+        // then: 원본 slug와 달라지고, _deleted_ 마커 형식 준수
+        assertThat(parentCategory.getSlug())
+                .isNotEqualTo("beauty")
+                .startsWith("beauty_deleted_")
+                .matches("beauty_deleted_\\d+_\\d+");
+    }
+
+    @Test
+    @DisplayName("대분류 삭제 후 동일 slug로 재등록 성공 - Issue #147")
+    void 대분류_삭제_후_동일_slug_재등록_성공() {
+        // given: 기존 카테고리 삭제
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory existing = parentCategory(1L, "뷰티", "beauty", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(existing));
+
+        adminCategoryService.deleteParentCategory(adminInfo, 1L);
+
+        // 삭제 후 slug는 변형되어 있어야 함
+        assertThat(existing.getSlug()).isNotEqualTo("beauty");
+
+        // when: 동일 slug "beauty"로 재등록 - 서비스 레벨 중복 체크가 통과해야 함
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty")).willReturn(false);
+        given(parentCategoryRepository.save(any(ParentCategory.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        ParentCategoryResponseDto result = adminCategoryService.createParentCategory(adminInfo, request("뷰티", "beauty", 1, 1));
+
+        // then: 예외 없이 성공, slug 그대로
+        assertThat(result.getSlug()).isEqualTo("beauty");
+    }
+
+    @Test
+    @DisplayName("긴 slug 삭제 시 100자 제한을 초과하지 않는다")
+    void 긴_slug_삭제_시_100자_초과하지_않는다() {
+        // given: slug가 100자 (최대 길이)
+        String longSlug = "a".repeat(100);
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", longSlug, 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+
+        // when
+        adminCategoryService.deleteParentCategory(adminInfo, 1L);
+
+        // then: 변환된 slug가 100자 이하이고 _deleted_ 마커 포함
+        assertThat(parentCategory.getSlug().length()).isLessThanOrEqualTo(100);
+        assertThat(parentCategory.getSlug()).contains("_deleted_");
+    }
+
+    @Test
+    @DisplayName("소분류 삭제 성공 - soft delete 및 slug 변경")
+    void 소분류_삭제_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        ChildCategory childCategory = childCategory(1L, parentCategory, "스킨케어", "skincare", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(childCategoryRepository.findByChildCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(childCategory));
+
+        // when
+        adminCategoryService.deleteChildCategory(adminInfo, 1L);
+
+        // then
+        assertThat(childCategory.getIsActive()).isZero();
+        assertThat(childCategory.getDeletedAt()).isNotNull();
+        assertThat(childCategory.getSlug()).matches("skincare_deleted_\\d+_\\d+");
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈

https://github.com/s4ngg/AP-React/issues/147

## 버그 원인
`slug` 컬럼에 `UNIQUE` DB 제약이 있는데, soft delete는 행을 DB에 남겨두므로
삭제 후 동일 slug로 재추가 시 DB 레벨에서 unique 충돌 → 500 에러 발생.

## 해결 방법
`deactivate()` 호출 시 slug를 `{원본slug}_deleted_{PK}_{timestamp}` 형태로 변경.
- PK 포함으로 동일 밀리초 내 중복 삭제 시에도 충돌 없음
- 서비스의 `existsBySlugAndDeletedAtIsNull()` 검증은 변경 없이 그대로 동작

## 변경 파일
- `ParentCategory.java` — `deactivate()` 수정, `generateDeletedSlug()` 추가, 상수 분리, 멱등성 가드
- `ChildCategory.java` — 동일 패턴 적용
- `AdminCategoryServiceImplTest.java` — 신규 테스트 4건 추가, 기존 삭제 테스트에 slug 단언 보강

## 테스트 추가 내역 (총 18개, 전부 통과)
- 대분류 삭제 시 slug가 `_deleted_` 마커 형태로 변경된다
- 대분류 삭제 후 동일 slug로 재등록 성공 (Issue #147 핵심 시나리오)
- 긴 slug 삭제 시 100자 제한을 초과하지 않는다 (경계값)
- 소분류 삭제 성공 - soft delete 및 slug 변경

## 비고
- 기존 soft-delete된 레코드(slug가 원본 형태로 남아있는 row)가 DB에 있다면
  동일 증상 재발 가능 → 운영 DB 상태 확인 필요