### PR TITLE
fix: 탈퇴 회원 노출 방지

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImpl.java
@@ -27,7 +27,7 @@ public class AdminMemberServiceImpl implements AdminMemberService {
     @Override
     public List<MemberListResponseDto> getMembers(AdminJwtUserInfoDto adminInfo) {
         getSuperAdmin(adminInfo);
-        return memberRepository.findAllByOrderByCreatedAtDesc()
+        return memberRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc()
                 .stream()
                 .map(MemberListResponseDto::from)
                 .collect(Collectors.toList());
@@ -37,7 +37,7 @@ public class AdminMemberServiceImpl implements AdminMemberService {
     @Transactional
     public void toggleMemberStatus(AdminJwtUserInfoDto adminInfo, Long memberId) {
         getSuperAdmin(adminInfo);
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         if (member.getStatus() == 1) member.suspend();
         else member.activate();

--- a/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImpl.java
@@ -69,7 +69,7 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
     public List<SellerListResponseDto> getSellers(AdminJwtUserInfoDto adminInfo) {
         getSuperAdmin(adminInfo);
         return sellerRepository
-                .findAllByStatusInAndDeletedAtIsNullOrderByCreatedAtDesc(List.of(SellerStatus.APPROVED, SellerStatus.SUSPENDED))
+                .findAllActiveMemberSellersByStatusIn(List.of(SellerStatus.APPROVED, SellerStatus.SUSPENDED))
                 .stream()
                 .map(SellerListResponseDto::from)
                 .toList();
@@ -80,7 +80,7 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
     public List<SellerListResponseDto> getPendingSellers(AdminJwtUserInfoDto adminInfo) {
         getSuperAdmin(adminInfo);
         return sellerRepository
-                .findAllByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(SellerStatus.PENDING)
+                .findAllActiveMemberSellersByStatus(SellerStatus.PENDING)
                 .stream()
                 .map(SellerListResponseDto::from)
                 .toList();
@@ -90,7 +90,7 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
     @Transactional
     public void toggleSellerStatus(AdminJwtUserInfoDto adminInfo, Long sellerId) {
         getSuperAdmin(adminInfo);
-        Seller seller = sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId)
+        Seller seller = sellerRepository.findActiveMemberSellerBySellerId(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
         if (seller.getStatus() == SellerStatus.APPROVED) {
             seller.suspend();
@@ -116,7 +116,7 @@ public class AdminSellerApprovalServiceImpl implements AdminSellerApprovalServic
     }
 
     private Seller getPendingSeller(Long sellerId) {
-        Seller seller = sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId)
+        Seller seller = sellerRepository.findActiveMemberSellerBySellerId(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
         if (seller.getStatus() != SellerStatus.PENDING) {
             throw new BusinessException(ErrorCode.APPROVAL_NOT_PENDING);

--- a/src/main/java/co/kr/allpick/domain/member/entity/Member.java
+++ b/src/main/java/co/kr/allpick/domain/member/entity/Member.java
@@ -101,7 +101,7 @@ public class Member extends BaseEntity {
     // 탈퇴 (Soft Delete)
     public void delete() {
         this.status = 0;
-
+        super.delete();
     }
 
     // 관리자 - 회원 정지

--- a/src/main/java/co/kr/allpick/domain/member/repository/MemberRepository.java
+++ b/src/main/java/co/kr/allpick/domain/member/repository/MemberRepository.java
@@ -13,7 +13,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Page<Member> findAll(Pageable pageable);
 	Optional<Member> findByEmail(String email);
 	boolean existsByEmail(String email);
-	List<Member> findAllByOrderByCreatedAtDesc();
+	Optional<Member> findByIdAndDeletedAtIsNull(Long memberId);
+	List<Member> findAllByDeletedAtIsNullOrderByCreatedAtDesc();
 	
 	@Query("SELECT m.email FROM Member m WHERE m.phone = :phone")
     Optional<String> findEmailByUserPhone(@Param("phone") String phone);

--- a/src/main/java/co/kr/allpick/domain/member/service/impl/AuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/member/service/impl/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import co.kr.allpick.domain.member.dto.LoginRequestDto;
 import co.kr.allpick.domain.member.dto.SignupRequestDto;
 import co.kr.allpick.domain.member.entity.Member;
 import co.kr.allpick.domain.member.repository.MemberRepository;
+import co.kr.allpick.domain.seller.entity.SellerStatus;
 import co.kr.allpick.global.config.JwtProvider;
 import co.kr.allpick.global.config.JwtUserInfoDto;
 import co.kr.allpick.global.exception.BusinessException;
@@ -79,7 +80,7 @@ public class AuthServiceImpl implements AuthService {
             logger.warn("[AuthService] 비밀번호 불일치 - memberId: {}", member.getId());
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
-        if (!Integer.valueOf(1).equals(member.getStatus())) {
+        if (!Integer.valueOf(1).equals(member.getStatus()) || member.getDeletedAt() != null) {
             logger.warn("[AuthService] 정지 회원 로그인 시도 - memberId: {}", member.getId());
             throw new BusinessException(ErrorCode.MEMBER_BLOCKED);
         }
@@ -90,7 +91,10 @@ public class AuthServiceImpl implements AuthService {
                 .email(member.getEmail())
                 .build());
 
-        boolean isSeller = sellerRepository.findByMemberId(member.getId()).isPresent();
+        boolean isSeller = sellerRepository.existsByMemberIdAndStatusAndDeletedAtIsNull(
+                member.getId(),
+                SellerStatus.APPROVED
+        );
 
         return AuthResponseDto.of(token, member, isSeller);
     }

--- a/src/main/java/co/kr/allpick/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/member/service/impl/MemberServiceImpl.java
@@ -35,9 +35,7 @@ public class MemberServiceImpl implements MemberService {
     @Transactional(readOnly = true)
     public MemberResponseDto getMember(Long memberId) {
         logger.info("[MemberService] 회원 정보 조회 - memberId: {}", memberId);
-        return memberRepository.findById(memberId)
-                .map(MemberResponseDto::from)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        return MemberResponseDto.from(findMemberById(memberId));
     }
 
     @Override
@@ -68,6 +66,7 @@ public class MemberServiceImpl implements MemberService {
     @Transactional(readOnly = true)
     public List<OrderResponseDto> getMyOrders(Long memberId) {
         logger.info("[MemberService] 회원 주문 목록 조회 - memberId: {}", memberId);
+        findMemberById(memberId);
         List<Order> orders = orderRepository.findByMemberIdExcludingPending(memberId);
 
         return orders.stream()
@@ -76,13 +75,12 @@ public class MemberServiceImpl implements MemberService {
     }
     
     @Override
-    public boolean
-    checkEmailDuplicate(String email) {
+    public boolean checkEmailDuplicate(String email) {
         return memberRepository.existsByEmail(email);
     }
 
     private Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/co/kr/allpick/domain/product/repository/ProductRepository.java
+++ b/src/main/java/co/kr/allpick/domain/product/repository/ProductRepository.java
@@ -19,10 +19,14 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     // 상품 상세 조회 - 판매중, 승인된, 삭제 안 된 상품만
     @Query("SELECT p FROM Product p " +
            "LEFT JOIN FETCH p.parentCategory " +
+           "JOIN FETCH p.seller s " +
+           "JOIN s.member m " +
            "WHERE p.productId = :id " +
            "AND p.status = 'ON_SALE' " +
            "AND p.approvalStatus = 'APPROVED' " +
-           "AND p.deletedAt IS NULL")
+           "AND p.deletedAt IS NULL " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL")
     Optional<Product> findValidProduct(@Param("id") Long productId);
 
     // 상품명 중복 확인 (삭제된 상품명은 재사용 가능)
@@ -40,7 +44,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p " +
            "JOIN FETCH p.seller s " +
            "JOIN s.member m " +
-           "WHERE p.productId = :productId AND m.id = :memberId AND p.deletedAt IS NULL")
+           "WHERE p.productId = :productId " +
+           "AND m.id = :memberId " +
+           "AND p.deletedAt IS NULL " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL")
     Optional<Product> findByProductIdAndMemberId(@Param("memberId") Long memberId, @Param("productId") Long productId);
 
     // 판매자 본인 상품 목록 조회 (삭제 안 된 상품만)
@@ -53,6 +61,20 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     // 판매 중이고 승인된 상품 목록 페이지 조회
     @EntityGraph(attributePaths = {"parentCategory"})
+    @Query("SELECT p FROM Product p " +
+           "JOIN p.seller s " +
+           "JOIN s.member m " +
+           "WHERE p.status = :status " +
+           "AND p.approvalStatus = :approvalStatus " +
+           "AND p.deletedAt IS NULL " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL")
+    Page<Product> findVisibleProducts(
+            @Param("status") Product.Status status,
+            @Param("approvalStatus") Product.ApprovalStatus approvalStatus,
+            Pageable pageable
+    );
+
     Page<Product> findByStatusAndApprovalStatusAndDeletedAtIsNull(
             Product.Status status,
             Product.ApprovalStatus approvalStatus,

--- a/src/main/java/co/kr/allpick/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/product/service/impl/ProductServiceImpl.java
@@ -76,7 +76,7 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public Page<ProductListResponseDto> getProductList(Pageable pageable) {
         logger.info("상품 목록 조회 - page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
-        return productRepository.findByStatusAndApprovalStatusAndDeletedAtIsNull(
+        return productRepository.findVisibleProducts(
                 Product.Status.ON_SALE,
                 Product.ApprovalStatus.APPROVED,
                 pageable

--- a/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/co/kr/allpick/domain/seller/repository/SellerRepository.java
@@ -17,24 +17,65 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
     boolean existsByBusinessNumber(String businessNumber);
 
     Optional<Seller> findByBusinessNumber(String businessNumber);
-    
+
     Optional<Seller> findBySellerIdAndDeletedAtIsNull(Long sellerId);
-    
+
     boolean existsByMemberId(Long memberId);
 
-    Optional<Seller> findByMemberIdAndDeletedAtIsNull(Long memberId);
-    
+    @Query("SELECT s FROM Seller s " +
+           "JOIN FETCH s.member m " +
+           "WHERE m.id = :memberId " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL")
+    Optional<Seller> findByMemberIdAndDeletedAtIsNull(@Param("memberId") Long memberId);
 
- // 판매자인지 검증 (새 상품 등록용)
-  	@Query("SELECT s FROM Seller s " +
-  		   "JOIN FETCH s.member m " + 
-  		   " WHERE m.id = :memberId " +
-  		   "AND s.deletedAt IS NULL ") 
-  	Optional<Seller> findWithMemberByMemberId(@Param("memberId") Long memberId);
+    @Query("SELECT s FROM Seller s " +
+           "JOIN FETCH s.member m " +
+           "WHERE m.id = :memberId " +
+           "AND s.status = 'APPROVED' " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL " +
+           "AND m.status = 1")
+    Optional<Seller> findWithMemberByMemberId(@Param("memberId") Long memberId);
 
-    boolean existsByMemberIdAndDeletedAtIsNull(Long memberId);
+    @Query("SELECT COUNT(s) > 0 FROM Seller s " +
+           "JOIN s.member m " +
+           "WHERE m.id = :memberId " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL")
+    boolean existsByMemberIdAndDeletedAtIsNull(@Param("memberId") Long memberId);
 
-    List<Seller> findAllByStatusInAndDeletedAtIsNullOrderByCreatedAtDesc(List<SellerStatus> statuses);
+    @Query("SELECT COUNT(s) > 0 FROM Seller s " +
+           "JOIN s.member m " +
+           "WHERE m.id = :memberId " +
+           "AND s.status = :status " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL")
+    boolean existsByMemberIdAndStatusAndDeletedAtIsNull(
+            @Param("memberId") Long memberId,
+            @Param("status") SellerStatus status
+    );
 
-    List<Seller> findAllByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(SellerStatus status);
+    @Query("SELECT s FROM Seller s " +
+           "JOIN FETCH s.member m " +
+           "WHERE s.sellerId = :sellerId " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL")
+    Optional<Seller> findActiveMemberSellerBySellerId(@Param("sellerId") Long sellerId);
+
+    @Query("SELECT s FROM Seller s " +
+           "JOIN FETCH s.member m " +
+           "WHERE s.status IN :statuses " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL " +
+           "ORDER BY s.createdAt DESC")
+    List<Seller> findAllActiveMemberSellersByStatusIn(@Param("statuses") List<SellerStatus> statuses);
+
+    @Query("SELECT s FROM Seller s " +
+           "JOIN FETCH s.member m " +
+           "WHERE s.status = :status " +
+           "AND s.deletedAt IS NULL " +
+           "AND m.deletedAt IS NULL " +
+           "ORDER BY s.createdAt DESC")
+    List<Seller> findAllActiveMemberSellersByStatus(@Param("status") SellerStatus status);
 }

--- a/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImpl.java
@@ -36,7 +36,7 @@ public class SellerAuthServiceImpl implements SellerAuthService {
 
     @Override
     public void update(Long sellerId, SellerUpdateRequestDto dto, Long memberId) {
-        Seller seller = sellerRepository.findById(sellerId)
+        Seller seller = sellerRepository.findActiveMemberSellerBySellerId(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
 
         validateSellerOwner(seller, memberId);
@@ -52,7 +52,7 @@ public class SellerAuthServiceImpl implements SellerAuthService {
 
     @Override
     public void deleteSeller(Long sellerId, Long memberId) {
-        Seller seller = sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId)
+        Seller seller = sellerRepository.findActiveMemberSellerBySellerId(sellerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
 
         validateSellerOwner(seller, memberId);  // ← 헬퍼 메서드로 교체
@@ -72,10 +72,13 @@ public class SellerAuthServiceImpl implements SellerAuthService {
             throw new BusinessException(ErrorCode.DUPLICATE_BUSINESS_NUMBER);
         }
 
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        
+        if (!Integer.valueOf(1).equals(member.getStatus())) {
+            logger.warn("[SellerAuthService] 정지 회원 판매자 등록 시도 - memberId: {}", memberId);
+            throw new BusinessException(ErrorCode.MEMBER_BLOCKED);
+        }
 
         Seller seller = dto.toEntity(member);
         sellerRepository.save(seller);
@@ -95,7 +98,7 @@ public class SellerAuthServiceImpl implements SellerAuthService {
             logger.warn("[SellerAuthService] 비밀번호 불일치 - memberId: {}", member.getId());
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
-        if (!Integer.valueOf(1).equals(member.getStatus())) {
+        if (!Integer.valueOf(1).equals(member.getStatus()) || member.getDeletedAt() != null) {
             logger.warn("[SellerAuthService] 정지 회원 판매자 로그인 시도 - memberId: {}", member.getId());
             throw new BusinessException(ErrorCode.MEMBER_BLOCKED);
         }

--- a/src/test/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/member/service/impl/AdminMemberServiceImplTest.java
@@ -41,7 +41,7 @@ class AdminMemberServiceImplTest {
         Member m1 = member(1L, 1);
         Member m2 = member(2L, 0);
         given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
-        given(memberRepository.findAllByOrderByCreatedAtDesc()).willReturn(List.of(m1, m2));
+        given(memberRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc()).willReturn(List.of(m1, m2));
 
         // when
         List<MemberListResponseDto> result = adminMemberService.getMembers(superAdminInfo());
@@ -58,7 +58,7 @@ class AdminMemberServiceImplTest {
         // given
         Member member = member(1L, 1);
         given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
-        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
 
         // when
         adminMemberService.toggleMemberStatus(superAdminInfo(), 1L);
@@ -73,7 +73,7 @@ class AdminMemberServiceImplTest {
         // given
         Member member = member(1L, 0);
         given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
-        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
 
         // when
         adminMemberService.toggleMemberStatus(superAdminInfo(), 1L);
@@ -87,7 +87,7 @@ class AdminMemberServiceImplTest {
     void 상태변경_실패_회원없음() {
         // given
         given(adminRepository.findById(1L)).willReturn(Optional.of(superAdmin()));
-        given(memberRepository.findById(999L)).willReturn(Optional.empty());
+        given(memberRepository.findByIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> adminMemberService.toggleMemberStatus(superAdminInfo(), 999L))

--- a/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/seller/service/impl/AdminSellerApprovalServiceImplTest.java
@@ -56,7 +56,7 @@ class AdminSellerApprovalServiceImplTest {
         Seller seller = seller(SellerStatus.PENDING);
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller));
         given(sellerApprovalRepository.save(any(SellerApproval.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -86,7 +86,7 @@ class AdminSellerApprovalServiceImplTest {
         SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(admin));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller));
         given(sellerApprovalRepository.save(any(SellerApproval.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -117,7 +117,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerRepository, never()).findActiveMemberSellerBySellerId(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -127,7 +127,7 @@ class AdminSellerApprovalServiceImplTest {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+        given(sellerRepository.findActiveMemberSellerBySellerId(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 999L))
@@ -149,7 +149,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerRepository, never()).findActiveMemberSellerBySellerId(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -159,7 +159,7 @@ class AdminSellerApprovalServiceImplTest {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
@@ -174,7 +174,7 @@ class AdminSellerApprovalServiceImplTest {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.REJECTED)));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller(SellerStatus.REJECTED)));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
@@ -189,7 +189,7 @@ class AdminSellerApprovalServiceImplTest {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.SUSPENDED)));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller(SellerStatus.SUSPENDED)));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
@@ -212,7 +212,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerRepository, never()).findActiveMemberSellerBySellerId(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -230,7 +230,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerRepository, never()).findActiveMemberSellerBySellerId(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -242,7 +242,7 @@ class AdminSellerApprovalServiceImplTest {
         SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+        given(sellerRepository.findActiveMemberSellerBySellerId(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 999L, request))
@@ -259,7 +259,7 @@ class AdminSellerApprovalServiceImplTest {
         SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller(SellerStatus.APPROVED)));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
@@ -276,7 +276,7 @@ class AdminSellerApprovalServiceImplTest {
         SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.REJECTED)));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller(SellerStatus.REJECTED)));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
@@ -293,7 +293,7 @@ class AdminSellerApprovalServiceImplTest {
         SellerRejectRequestDto request = new SellerRejectRequestDto("사업자등록번호 확인 필요");
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller(SellerStatus.SUSPENDED)));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller(SellerStatus.SUSPENDED)));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.rejectSeller(adminInfo, 1L, request))
@@ -313,7 +313,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_NOT_FOUND);
-        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerRepository, never()).findActiveMemberSellerBySellerId(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -336,7 +336,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.approveSeller(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerRepository, never()).findActiveMemberSellerBySellerId(any());
         verify(sellerApprovalRepository, never()).save(any());
     }
 
@@ -351,7 +351,7 @@ class AdminSellerApprovalServiceImplTest {
         Seller suspendedSeller = sellerWithMember(SellerStatus.SUSPENDED);
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findAllByStatusInAndDeletedAtIsNullOrderByCreatedAtDesc(
+        given(sellerRepository.findAllActiveMemberSellersByStatusIn(
                 List.of(SellerStatus.APPROVED, SellerStatus.SUSPENDED)))
                 .willReturn(List.of(approvedSeller, suspendedSeller));
 
@@ -374,7 +374,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.getSellers(adminInfo))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findAllByStatusInAndDeletedAtIsNullOrderByCreatedAtDesc(any());
+        verify(sellerRepository, never()).findAllActiveMemberSellersByStatusIn(any());
     }
 
     @Test
@@ -386,7 +386,7 @@ class AdminSellerApprovalServiceImplTest {
         Seller pendingSeller2 = sellerWithMember(SellerStatus.PENDING);
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findAllByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(SellerStatus.PENDING))
+        given(sellerRepository.findAllActiveMemberSellersByStatus(SellerStatus.PENDING))
                 .willReturn(List.of(pendingSeller1, pendingSeller2));
 
         // when
@@ -404,7 +404,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.getPendingSellers(null))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findAllByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(any());
+        verify(sellerRepository, never()).findAllActiveMemberSellersByStatus(any());
     }
 
     @Test
@@ -415,7 +415,7 @@ class AdminSellerApprovalServiceImplTest {
         Seller seller = seller(SellerStatus.APPROVED);
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller));
 
         // when
         adminSellerApprovalService.toggleSellerStatus(adminInfo, 1L);
@@ -432,7 +432,7 @@ class AdminSellerApprovalServiceImplTest {
         Seller seller = seller(SellerStatus.SUSPENDED);
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller));
 
         // when
         adminSellerApprovalService.toggleSellerStatus(adminInfo, 1L);
@@ -451,7 +451,7 @@ class AdminSellerApprovalServiceImplTest {
         assertThatThrownBy(() -> adminSellerApprovalService.toggleSellerStatus(adminInfo, 1L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADMIN_FORBIDDEN);
-        verify(sellerRepository, never()).findBySellerIdAndDeletedAtIsNull(any());
+        verify(sellerRepository, never()).findActiveMemberSellerBySellerId(any());
     }
 
     @Test
@@ -462,7 +462,7 @@ class AdminSellerApprovalServiceImplTest {
         Seller seller = seller(SellerStatus.PENDING);
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.toggleSellerStatus(adminInfo, 1L))
@@ -479,7 +479,7 @@ class AdminSellerApprovalServiceImplTest {
         Seller seller = seller(SellerStatus.REJECTED);
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(seller));
+        given(sellerRepository.findActiveMemberSellerBySellerId(1L)).willReturn(Optional.of(seller));
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.toggleSellerStatus(adminInfo, 1L))
@@ -495,7 +495,7 @@ class AdminSellerApprovalServiceImplTest {
         AdminJwtUserInfoDto adminInfo = superAdminInfo();
 
         given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+        given(sellerRepository.findActiveMemberSellerBySellerId(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> adminSellerApprovalService.toggleSellerStatus(adminInfo, 999L))

--- a/src/test/java/co/kr/allpick/domain/member/service/Impl/AuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/member/service/Impl/AuthServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +31,7 @@ import co.kr.allpick.domain.member.entity.Member;
 import co.kr.allpick.domain.member.repository.MemberRepository;
 import co.kr.allpick.domain.member.service.impl.AuthServiceImpl;
 import co.kr.allpick.domain.member.sms.service.SmsService;
-import co.kr.allpick.domain.seller.entity.Seller;
+import co.kr.allpick.domain.seller.entity.SellerStatus;
 import co.kr.allpick.domain.seller.repository.SellerRepository;
 import co.kr.allpick.global.config.JwtProvider;
 import co.kr.allpick.global.config.JwtUserInfoDto;
@@ -150,7 +151,8 @@ class AuthServiceImplTest {
         when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(mockMember));
         when(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).thenReturn(true);
         when(jwtProvider.createToken(any(JwtUserInfoDto.class))).thenReturn("mockToken");
-        when(sellerRepository.findByMemberId(any())).thenReturn(Optional.empty());
+        given(sellerRepository.existsByMemberIdAndStatusAndDeletedAtIsNull(any(), any()))
+                .willReturn(false);
 
         AuthResponseDto result = authService.login(dto);
 
@@ -174,14 +176,13 @@ class AuthServiceImplTest {
                 .address("서울시 강남구")
                 .build();
 
-        Seller mockSeller = Seller.builder()
-                .member(mockMember)
-                .build();
-
         when(memberRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(mockMember));
         when(passwordEncoder.matches(dto.getPassword(), mockMember.getPassword())).thenReturn(true);
         when(jwtProvider.createToken(any(JwtUserInfoDto.class))).thenReturn("mockToken");
-        when(sellerRepository.findByMemberId(any())).thenReturn(Optional.of(mockSeller));
+        given(sellerRepository.existsByMemberIdAndStatusAndDeletedAtIsNull(
+                any(),
+                eq(SellerStatus.APPROVED)
+        )).willReturn(true);
 
         AuthResponseDto result = authService.login(dto);
 

--- a/src/test/java/co/kr/allpick/domain/member/service/Impl/MemberServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/member/service/Impl/MemberServiceImplTest.java
@@ -81,7 +81,7 @@ class MemberServiceImplTest {
         @DisplayName("success")
         void getMember_success() {
             Member member = createMember();
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
 
             MemberResponseDto result = memberService.getMember(1L);
 
@@ -94,7 +94,7 @@ class MemberServiceImplTest {
         @Test
         @DisplayName("fail when member does not exist")
         void getMember_memberNotFound() {
-            given(memberRepository.findById(1L)).willReturn(Optional.empty());
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> memberService.getMember(1L))
                     .isInstanceOf(BusinessException.class)
@@ -115,7 +115,7 @@ class MemberServiceImplTest {
                     "01087654321",
                     "Busan"
             );
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
 
             MemberResponseDto result = memberService.updateMember(1L, request);
 
@@ -135,7 +135,7 @@ class MemberServiceImplTest {
                     "01087654321",
                     "Busan"
             );
-            given(memberRepository.findById(1L)).willReturn(Optional.empty());
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> memberService.updateMember(1L, request))
                     .isInstanceOf(BusinessException.class)
@@ -152,7 +152,7 @@ class MemberServiceImplTest {
         void changePassword_success_updatesEncodedPassword() {
             Member member = createMemberWithPassword("encodedOldPassword");
             PasswordChangeRequestDto request = new PasswordChangeRequestDto("OldPass1!", "NewPass1!");
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
             given(passwordEncoder.matches(request.getCurrentPassword(), "encodedOldPassword")).willReturn(true);
             given(passwordEncoder.matches(request.getNewPassword(), "encodedOldPassword")).willReturn(false);
             given(passwordEncoder.encode(request.getNewPassword())).willReturn("encodedNewPassword");
@@ -167,7 +167,7 @@ class MemberServiceImplTest {
         @DisplayName("fail when member does not exist")
         void changePassword_memberNotFound() {
             PasswordChangeRequestDto request = new PasswordChangeRequestDto("OldPass1!", "NewPass1!");
-            given(memberRepository.findById(1L)).willReturn(Optional.empty());
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> memberService.changePassword(1L, request))
                     .isInstanceOf(BusinessException.class)
@@ -179,7 +179,7 @@ class MemberServiceImplTest {
         void changePassword_currentPasswordMismatch() {
             Member member = createMemberWithPassword("encodedOldPassword");
             PasswordChangeRequestDto request = new PasswordChangeRequestDto("WrongPass1!", "NewPass1!");
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
             given(passwordEncoder.matches(request.getCurrentPassword(), "encodedOldPassword")).willReturn(false);
 
             assertThatThrownBy(() -> memberService.changePassword(1L, request))
@@ -192,7 +192,7 @@ class MemberServiceImplTest {
         void changePassword_samePassword() {
             Member member = createMemberWithPassword("encodedOldPassword");
             PasswordChangeRequestDto request = new PasswordChangeRequestDto("OldPass1!", "OldPass1!");
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
             given(passwordEncoder.matches(request.getCurrentPassword(), "encodedOldPassword")).willReturn(true);
             given(passwordEncoder.matches(request.getNewPassword(), "encodedOldPassword")).willReturn(true);
 
@@ -206,7 +206,7 @@ class MemberServiceImplTest {
         void changePassword_currentMismatchStopsBeforeEncode() {
             Member member = createMemberWithPassword("encodedOldPassword");
             PasswordChangeRequestDto request = new PasswordChangeRequestDto("WrongPass1!", "NewPass1!");
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
             given(passwordEncoder.matches(request.getCurrentPassword(), "encodedOldPassword")).willReturn(false);
 
             assertThatThrownBy(() -> memberService.changePassword(1L, request))
@@ -224,17 +224,19 @@ class MemberServiceImplTest {
         @DisplayName("success and changes status to zero")
         void deleteMember_success_setsStatusZero() {
             Member member = createMember();
-            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(member));
 
             memberService.deleteMember(1L);
 
             assertThat(member.getStatus()).isZero();
+            assertThat(member.getDeletedAt()).isNotNull();
+            assertThat(member.getEmail()).isEqualTo("member@allpick.com");
         }
 
         @Test
         @DisplayName("fail when member does not exist")
         void deleteMember_memberNotFound() {
-            given(memberRepository.findById(1L)).willReturn(Optional.empty());
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> memberService.deleteMember(1L))
                     .isInstanceOf(BusinessException.class)
@@ -249,7 +251,8 @@ class MemberServiceImplTest {
         @Test
         @DisplayName("returns empty list when there are no orders")
         void getMyOrders_emptyList() {
-            given(orderRepository.findByMemberIdOrderByOrderedAtDesc(1L)).willReturn(Collections.emptyList());
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(createMember()));
+            given(orderRepository.findByMemberIdExcludingPending(1L)).willReturn(Collections.emptyList());
 
             List<OrderResponseDto> result = memberService.getMyOrders(1L);
 
@@ -270,7 +273,8 @@ class MemberServiceImplTest {
                     .status(Order.OrderStatus.PAID)
                     .orderedAt(LocalDateTime.of(2026, 5, 2, 10, 0))
                     .build();
-            given(orderRepository.findByMemberIdOrderByOrderedAtDesc(1L)).willReturn(List.of(order));
+            given(memberRepository.findByIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(createMember()));
+            given(orderRepository.findByMemberIdExcludingPending(1L)).willReturn(List.of(order));
 
             List<OrderResponseDto> result = memberService.getMyOrders(1L);
 

--- a/src/test/java/co/kr/allpick/domain/product/service/impl/ProductServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/product/service/impl/ProductServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -219,9 +220,9 @@ class ProductServiceImplTest {
         Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Product> mockPage = new PageImpl<>(List.of(mockProduct), pageable, 1);
 
-        when(productRepository.findByStatusAndApprovalStatusAndDeletedAtIsNull(
+        given(productRepository.findVisibleProducts(
                 Product.Status.ON_SALE, Product.ApprovalStatus.APPROVED, pageable))
-                .thenReturn(mockPage);
+                .willReturn(mockPage);
 
         Page<ProductListResponseDto> result = productService.getProductList(pageable);
 
@@ -237,9 +238,9 @@ class ProductServiceImplTest {
         Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Product> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
-        when(productRepository.findByStatusAndApprovalStatusAndDeletedAtIsNull(
+        given(productRepository.findVisibleProducts(
                 Product.Status.ON_SALE, Product.ApprovalStatus.APPROVED, pageable))
-                .thenReturn(emptyPage);
+                .willReturn(emptyPage);
 
         Page<ProductListResponseDto> result = productService.getProductList(pageable);
 

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerAuthServiceImplTest.java
@@ -58,7 +58,7 @@ class SellerAuthServiceImplTest {
                 .build();
 
         given(sellerRepository.existsByBusinessNumber(dto.getBusinessNumber())).willReturn(false);
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(mockMember));
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(mockMember));
 
         // when
         sellerAuthService.signup(dto, memberId);
@@ -92,7 +92,7 @@ class SellerAuthServiceImplTest {
                 "나이키 코리아", "1234567890", "홍길동", "국민은행", "12345678901234");
 
         given(sellerRepository.existsByBusinessNumber(dto.getBusinessNumber())).willReturn(false);
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+        given(memberRepository.findByIdAndDeletedAtIsNull(memberId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> sellerAuthService.signup(dto, memberId))
@@ -122,13 +122,13 @@ class SellerAuthServiceImplTest {
                 .member(mockMember)
                 .build();
 
-        given(sellerRepository.findById(sellerId)).willReturn(Optional.of(mockSeller));
+        given(sellerRepository.findActiveMemberSellerBySellerId(sellerId)).willReturn(Optional.of(mockSeller));
 
         // when
         sellerAuthService.update(sellerId, dto, memberId);
 
         // then
-        verify(sellerRepository, times(1)).findById(sellerId);
+        verify(sellerRepository, times(1)).findActiveMemberSellerBySellerId(sellerId);
     }
 
     @Test
@@ -140,7 +140,7 @@ class SellerAuthServiceImplTest {
         SellerUpdateRequestDto dto = new SellerUpdateRequestDto(
                 "아디다스 코리아", "김철수", "신한은행", "98765432101234");
 
-        given(sellerRepository.findById(sellerId)).willReturn(Optional.empty());
+        given(sellerRepository.findActiveMemberSellerBySellerId(sellerId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> sellerAuthService.update(sellerId, dto, memberId))
@@ -277,7 +277,7 @@ class SellerAuthServiceImplTest {
                 .member(mockMember)
                 .build();
 
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId))
+        given(sellerRepository.findActiveMemberSellerBySellerId(sellerId))
                 .willReturn(Optional.of(mockSeller));
 
         // when
@@ -294,7 +294,7 @@ class SellerAuthServiceImplTest {
         Long sellerId = 999L;
         Long memberId = 1L;
 
-        given(sellerRepository.findBySellerIdAndDeletedAtIsNull(sellerId))
+        given(sellerRepository.findActiveMemberSellerBySellerId(sellerId))
                 .willReturn(Optional.empty());
 
         // when & then


### PR DESCRIPTION
﻿## 개요
- 탈퇴한 회원이 관리자 회원 목록 및 판매자/상품 노출 흐름에 남아 보이는 문제를 수정했습니다.

---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller: 변경 없음
- Service:
  - 회원 조회/수정/비밀번호 변경/주문 조회 시 탈퇴 회원 제외
  - 일반 로그인/판매자 로그인에서 탈퇴 회원 차단
  - 관리자 회원/판매자 관리 조회에서 탈퇴 회원 관련 데이터 제외
- Repository:
  - `MemberRepository`에 `deletedAt IS NULL` 기준 조회 추가
  - `SellerRepository` 조회 시 연결된 회원의 `deletedAt`도 함께 검증
  - `ProductRepository` 상품 목록/상세 조회 시 탈퇴 판매자 회원의 상품 제외
- 기타:
  - 회원 탈퇴 시 `deletedAt`이 세팅되도록 `Member.delete()` 보완
  - 관련 서비스 테스트 mock을 변경된 조회 기준에 맞게 수정

---

## 관련 이슈
- s4ngg/AP-React close #155
github.com/s4ngg/AP-React/issues/155
---

## 변경 전 / 후
### Before
- 회원 탈퇴 후에도 `deletedAt`이 세팅되지 않아 관리자 페이지에서 회원이 계속 조회될 수 있었습니다.
- 탈퇴 회원과 연결된 판매자/상품 데이터가 일부 조회 흐름에 남아 노출될 수 있었습니다.

### After
- 탈퇴 시 `status = 0`과 함께 `deletedAt`이 세팅됩니다.
- 관리자 회원 목록, 마이페이지 조회, 로그인, 판매자 관리, 상품 목록/상세 조회에서 탈퇴 회원 관련 데이터가 제외됩니다.
- 기존 이메일은 유지하므로 탈퇴 회원이 같은 이메일로 재가입하는 흐름은 계속 차단됩니다.

---

## 테스트
- [x] `./gradlew.bat compileJava`
- [x] `git diff --check`
- [ ] `./gradlew.bat compileTestJava`

### 테스트 참고
`compileTestJava`는 이번 수정 범위가 아닌 `src/test/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java` 파일에서 실패합니다. 현재 해당 파일이 테스트 소스 경로에 구현 클래스 형태로 들어가 있어 final 필드 생성자 초기화 오류가 발생합니다. @s4ngg 

```text
src/test/java/co/kr/allpick/domain/order/service/impl/OrderServiceImpl.java:45
variable productRepository not initialized in the default constructor

```
