### PR TITLE
fix: 카테고리 slug 중복 시 에러 메시지 개선

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImpl.java
@@ -196,14 +196,14 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
 
     private void validateSlugForCreate(String slug) {
         if (isSlugDuplicated(slug)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.CATEGORY_SLUG_DUPLICATED);
         }
     }
 
     private void validateSlugForUpdate(String requestSlug, String currentSlug) {
         String trimmedSlug = requestSlug.trim();
         if (!trimmedSlug.equals(currentSlug) && isSlugDuplicated(trimmedSlug)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.CATEGORY_SLUG_DUPLICATED);
         }
     }
 

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -109,6 +109,7 @@ public enum ErrorCode {
 
     // Category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
+    CATEGORY_SLUG_DUPLICATED(HttpStatus.CONFLICT, "CATEGORY_SLUG_DUPLICATED", "이미 사용 중인 카테고리 URL입니다."),
 
     // image
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_UPLOAD_FAILED", "이미지 업로드에 실패했습니다."),

--- a/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
@@ -107,7 +107,7 @@ class AdminCategoryServiceImplTest {
         // when & then
         assertThatThrownBy(() -> adminCategoryService.createParentCategory(adminInfo, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_SLUG_DUPLICATED);
         verify(parentCategoryRepository, never()).save(any());
     }
 
@@ -272,6 +272,27 @@ class AdminCategoryServiceImplTest {
         assertThat(captor.getValue().getParentCategory()).isEqualTo(parentCategory);
         assertThat(captor.getValue().getCategoryName()).isEqualTo("스킨케어");
         assertThat(captor.getValue().getSlug()).isEqualTo("skincare");
+    }
+
+    @Test
+    @DisplayName("소분류 등록 실패 - slug 중복")
+    void 소분류_등록_실패_slug중복() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        AdminCategoryRequestDto request = request("스킨케어", "skincare", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("skincare")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("skincare")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.createChildCategory(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_SLUG_DUPLICATED);
+        verify(childCategoryRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
관리자 페이지 카테고리 관리에서 이미 존재하는 slug 입력 시 "잘못된 입력값입니다." 노출 문제

## 작업 내용
- [x] 버그 수정

### 주요 변경 사항
- ErrorCode: `CATEGORY_SLUG_DUPLICATED(409, "이미 사용 중인 카테고리 URL입니다.")` 추가 (`global/` — 팀장 사전 승인 완료)
- Service: `validateSlugForCreate()` / `validateSlugForUpdate()` 양쪽 모두 `INVALID_INPUT` → `CATEGORY_SLUG_DUPLICATED` 변경
- Test: 대분류 slug 중복 테스트 단언 수정, 소분류 slug 중복 테스트 신규 추가 (총 19개 통과)

---

## 변경 전 / 후

### Before
- slug 중복 시 HTTP 400 + `"잘못된 입력값입니다."` 노출
- 생성(`POST`) API만 수정 → 수정(`PATCH`) API에서 동일 UX 버그 잔존

### After
- slug 중복 시 HTTP 409 + `"이미 사용 중인 카테고리 URL입니다."` 노출
- 생성·수정 API 양쪽 모두 반영
- 프론트 별도 수정 불필요 (`error.response?.data?.message` 자동 반영)