### PR TITLE
fix: 클레임 상품명 조회 및 직접 방문 반납 배송비 미부과 처리

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
@@ -106,7 +106,9 @@ public class ClaimServiceImpl implements ClaimService {
         BigDecimal productTotal = orderItem.getProductPrice()
                 .multiply(BigDecimal.valueOf(orderItem.getQuantity()));
         boolean isSimpleReason = SIMPLE_REASON_CODES.contains(request.getReasonCode());
-        BigDecimal shippingFee = isSimpleReason ? ROUND_TRIP_SHIPPING_FEE : BigDecimal.ZERO;
+        boolean isCourier = request.getPickupMethod() == Claim.ClaimPickupMethod.COURIER;
+        // 단순 변심 계열 사유 + 택배 수거일 때만 왕복 배송비 부과 (직접 방문 반납은 배송비 없음)
+        BigDecimal shippingFee = (isSimpleReason && isCourier) ? ROUND_TRIP_SHIPPING_FEE : BigDecimal.ZERO;
         // 음수인 경우 고객이 추가 결제해야 하는 금액을 의미
         BigDecimal refundAmount = productTotal.subtract(shippingFee);
 
@@ -127,9 +129,28 @@ public class ClaimServiceImpl implements ClaimService {
     @Override
     @Transactional(readOnly = true)
     public List<ClaimResponseDto> getMyClaims(Long memberId) {
-        return claimRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+        List<Claim> claims = claimRepository.findByMemberIdAndDeletedAtIsNull(memberId);
+        if (claims.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, OrderItem> orderItemMap = orderItemRepository
+                .findAllWithOrderMemberAndProductByOrderItemIdIn(
+                        claims.stream()
+                                .map(Claim::getOrderItemId)
+                                .distinct()
+                                .toList()
+                )
                 .stream()
-                .map(ClaimResponseDto::from)
+                .collect(Collectors.toMap(OrderItem::getOrderItemId, Function.identity()));
+
+        return claims.stream()
+                .map(claim -> {
+                    OrderItem orderItem = orderItemMap.get(claim.getOrderItemId());
+                    return orderItem == null
+                            ? ClaimResponseDto.from(claim)
+                            : ClaimResponseDto.from(claim, orderItem);
+                })
                 .toList();
     }
 


### PR DESCRIPTION
- getMyClaims: OrderItem 배치 조회로 productName 포함하여 응답
- createClaim: 직접 방문 반납(VISIT) 시 왕복 배송비 미부과

## 개요
- 클레임 목록 조회 시 상품명 누락 및 직접 방문 반납 시 배송비 잘못 부과되는 문제 수정

---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller:
- Service:
  - getMyClaims: OrderItem 배치 조회로 productName 포함하여 응답
  - createClaim: 직접 방문 반납(VISIT) 시 왕복 배송비 미부과
- Repository:
- 기타:

---

## 관련 이슈
- 관련 이슈: #179 (React)

---

## 변경 전 / 후
### Before
- 클레임 목록 조회 시 productName이 null로 응답되어 고객 화면에서 "주문 상품 #23" 형태로 표시됨
- 직접 방문 반납(VISIT) 선택 시에도 왕복 배송비 6,000원이 refundAmount에서 차감 되어 저장됨

### After
- getMyClaims에서 OrderItem 배치 조회로 productName 포함하여 응답
- 직접 방문 반납 시 shippingFee = 0원, refundAmount = 상품 금액 전액