### PR TITLE
fix: 관리자/고객/판매자 문의 목록 조회 시 createdAt DESC 정렬 적용

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/repository/InquiryRepository.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/repository/InquiryRepository.java
@@ -6,14 +6,14 @@ import java.util.List;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 
-    // 회원별 문의 목록 조회 (삭제 안된 것만)
-    List<Inquiry> findByMemberIdAndDeletedAtIsNull(Long memberId);
+    // 회원별 문의 목록 조회 (삭제 안된 것만, 최신순)
+    List<Inquiry> findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
 
-    // 전체 문의 목록 조회 (삭제 안된 것만)
-    List<Inquiry> findAllByDeletedAtIsNull();
+    // 전체 문의 목록 조회 (삭제 안된 것만, 최신순)
+    List<Inquiry> findAllByDeletedAtIsNullOrderByCreatedAtDesc();
 
-    // 판매자 상품에 달린 문의 목록 조회
-    List<Inquiry> findByProductIdInAndDeletedAtIsNull(List<Long>productIds);
+    // 판매자 상품에 달린 문의 목록 조회 (최신순)
+    List<Inquiry> findByProductIdInAndDeletedAtIsNullOrderByCreatedAtDesc(List<Long> productIds);
 
 }
 

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
@@ -100,7 +100,7 @@ public class InquiryServiceImpl implements InquiryService {
     @Override
     @Transactional(readOnly = true)
     public List<InquiryResponseDto> getMyInquiries(Long memberId) {
-        return inquiryRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+        return inquiryRepository.findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(memberId)
                 .stream()
                 .map(inquiry -> InquiryResponseDto.from(
                         inquiry,
@@ -115,7 +115,7 @@ public class InquiryServiceImpl implements InquiryService {
     @Override
     @Transactional(readOnly = true)
     public List<InquiryResponseDto> getAllInquiries() {
-        return inquiryRepository.findAllByDeletedAtIsNull()
+        return inquiryRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc()
                 .stream()
                 .map(inquiry -> InquiryResponseDto.from(
                         inquiry,
@@ -138,7 +138,7 @@ public class InquiryServiceImpl implements InquiryService {
                 .map(Product::getProductId)
                 .toList();
 
-        return inquiryRepository.findByProductIdInAndDeletedAtIsNull(productIds)
+        return inquiryRepository.findByProductIdInAndDeletedAtIsNullOrderByCreatedAtDesc(productIds)
                 .stream()
                 .map(inquiry -> InquiryResponseDto.from(
                         inquiry,


### PR DESCRIPTION
## 개요
- 문의 목록 조회 시 최신 문의가 상단에 표시되도록 DB 정렬 적용

---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller: 없음
- Service:
  - InquiryServiceImpl: 관리자/고객/판매자 문의 목록 조회 메서드 최신순 정렬로 변경
- Repository:
  - InquiryRepository: 문의 목록 조회 메서드 3개에 OrderByCreatedAtDesc 추가
- 기타: 없음

---

## 관련 이슈
- 관련 이슈: #177 (React)
---

## 변경 전 / 후
### Before
- InquiryRepository 조회 메서드에 정렬 조건이 없어 등록 순서대로 반환되어 최신 문의가 하단에 위치

### After
- 관리자/고객/판매자 문의 목록 조회 시 createdAt DESC 정렬 적용
- 최신 문의가 항상 상단에 표시