### PR TITLE
fix: 관리자 클레임 처리 상태 검증 강화

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
@@ -56,10 +56,10 @@ public interface ClaimControllerDocs {
     })
     ResponseEntity<ApiResponse<List<ClaimResponseDto>>> getSellerClaims(
             @AuthenticationPrincipal JwtUserInfoDto userInfo);
-    @Operation(summary = "클레임 상태 변경", description = "관리자 또는 판매자가 클레임 상태를 변경합니다.")
+    @Operation(summary = "클레임 상태 변경", description = "관리자가 판매자 확인(IN_PROGRESS)이 끝난 클레임을 완료(COMPLETED) 처리합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "클레임 상태 변경 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 완료되거나 거부된 클레임"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "판매자 확인 전이거나 이미 완료/거부된 클레임"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 클레임")
     })
     ResponseEntity<ApiResponse<ClaimResponseDto>> updateStatus(
@@ -67,10 +67,10 @@ public interface ClaimControllerDocs {
             @Parameter(description = "클레임 ID") @PathVariable("claimId") Long claimId,
             @RequestBody @Valid ClaimStatusUpdateRequestDto request);
 
-    @Operation(summary = "클레임 거부", description = "관리자 또는 판매자가 클레임을 거부합니다.")
+    @Operation(summary = "클레임 거부", description = "관리자가 판매자 확인(IN_PROGRESS)이 끝난 클레임을 거부합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "클레임 거부 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 완료되거나 거부된 클레임"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "판매자 확인 전이거나 이미 완료/거부된 클레임"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 클레임")
     })
     ResponseEntity<ApiResponse<ClaimResponseDto>> rejectClaim(

--- a/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/controller/docs/ClaimControllerDocs.java
@@ -100,10 +100,9 @@ public interface ClaimControllerDocs {
             @AuthenticationPrincipal JwtUserInfoDto userInfo,
             @Parameter(description = "클레임 ID") @PathVariable("claimId") Long claimId);
 
-    @Operation(summary = "클레임 거부 (판매자)", description = "판매자가 자신의 상품 클레임을 거부합니다.")
+    @Operation(summary = "클레임 거부 (판매자, 지원하지 않음)", description = "판매자는 클레임을 최종 거부하지 않습니다. 판매자 승인 후 관리자가 최종 승인 또는 거부합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "클레임 거부 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 완료/거부/취소된 클레임"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "판매자 거부는 지원하지 않음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 클레임에 대한 권한 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 클레임 또는 판매자")
     })

--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/ClaimStatusUpdateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/ClaimStatusUpdateRequestDto.java
@@ -14,6 +14,6 @@ import lombok.NoArgsConstructor;
 public class ClaimStatusUpdateRequestDto {
 
     @NotNull
-    @Schema(description = "변경할 클레임 상태", example = "IN_PROGRESS", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "관리자 완료 처리 상태", example = "COMPLETED", requiredMode = Schema.RequiredMode.REQUIRED)
     private Claim.ClaimStatus status;
 }

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/ClaimService.java
@@ -22,19 +22,19 @@ public interface ClaimService {
     // 전체 클레임 목록 조회 (관리자)
     List<ClaimResponseDto> getAllClaims(AdminJwtUserInfoDto adminInfo);
 
-    // 클레임 상태 변경 (관리자/판매자)
+    // 클레임 상태 변경 (관리자)
     ClaimResponseDto updateStatus(AdminJwtUserInfoDto adminInfo, Long claimId, ClaimStatusUpdateRequestDto request);
 
-    // 클레임 거부 (관리자/판매자)
+    // 클레임 거부 (관리자)
     ClaimResponseDto rejectClaim(AdminJwtUserInfoDto adminInfo, Long claimId, ClaimRejectRequestDto request);
 
     // 클레임 취소 (회원)
     void cancelClaim(Long claimId, Long memberId);
     
-    // 클레임 승인 (관리자/판매자)
+    // 클레임 승인 (판매자)
     ClaimResponseDto approveClaim(Long claimId, Long memberId);
     
-    // 클레임 거부 (판매자)
+    // 클레임 거부 (판매자, 현재 지원하지 않음)
     ClaimResponseDto rejectClaimBySeller(Long claimId, ClaimRejectRequestDto request, Long memberId);
     
     // 판매자 클레임 목록 조회

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
@@ -60,9 +60,8 @@ public class ClaimServiceImpl implements ClaimService {
     );
     private static final BigDecimal ROUND_TRIP_SHIPPING_FEE = new BigDecimal("6000");
 
-    // 허용된 상태 전이 규칙: SUBMITTED → IN_PROGRESS → COMPLETED
+    // 관리자 허용 상태 전이: 판매자 확인이 끝난 IN_PROGRESS 클레임만 최종 완료 처리
     private static final Map<Claim.ClaimStatus, Set<Claim.ClaimStatus>> ALLOWED_TRANSITIONS = Map.of(
-            Claim.ClaimStatus.SUBMITTED, Set.of(Claim.ClaimStatus.IN_PROGRESS),
             Claim.ClaimStatus.IN_PROGRESS, Set.of(Claim.ClaimStatus.COMPLETED)
     );
 
@@ -227,22 +226,14 @@ public class ClaimServiceImpl implements ClaimService {
         Claim claim = claimRepository.findById(claimId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CLAIM_NOT_FOUND));
 
-        if (claim.getStatus() == Claim.ClaimStatus.COMPLETED) {
-            throw new BusinessException(ErrorCode.CLAIM_ALREADY_COMPLETED);
-        }
-        if (claim.getStatus() == Claim.ClaimStatus.CANCELLED) {
-            throw new BusinessException(ErrorCode.CLAIM_ALREADY_CANCELLED);
-        }
-        if (claim.getStatus() == Claim.ClaimStatus.REJECTED) {
-            throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
-        }
+        validateAdminRejectableStatus(claim);
 
         claim.reject(request.getRejectReason());
         logger.info("[ClaimService] 관리자 클레임 거부 - actorAdminId: {}, claimId: {}",
                 admin.getAdminId(), claimId);
         return ClaimResponseDto.from(claim);
     }
- // ✅ 8. 클레임 승인 (판매자) SUBMITTED → IN_PROGRESS
+    // 8. 클레임 승인 (판매자) SUBMITTED → IN_PROGRESS
     @Override
     @Transactional
     public ClaimResponseDto approveClaim(Long claimId, Long memberId) {
@@ -260,7 +251,7 @@ public class ClaimServiceImpl implements ClaimService {
         return ClaimResponseDto.from(claim);
     }
 
-    // ✅ 9. 클레임 거부 (판매자)
+    // 9. 클레임 거부 (판매자)
     @Override
     @Transactional
     public ClaimResponseDto rejectClaimBySeller(Long claimId, ClaimRejectRequestDto request, Long memberId) {
@@ -273,6 +264,24 @@ public class ClaimServiceImpl implements ClaimService {
         claim.reject(request.getRejectReason());
         logger.info("[ClaimService] 판매자 클레임 거부 - claimId: {}, memberId: {}", claimId, memberId);
         return ClaimResponseDto.from(claim);
+    }
+
+    private void validateAdminRejectableStatus(Claim claim) {
+        if (claim.getStatus() == Claim.ClaimStatus.SUBMITTED) {
+            throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
+        }
+        if (claim.getStatus() == Claim.ClaimStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.CLAIM_ALREADY_COMPLETED);
+        }
+        if (claim.getStatus() == Claim.ClaimStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.CLAIM_ALREADY_CANCELLED);
+        }
+        if (claim.getStatus() == Claim.ClaimStatus.REJECTED) {
+            throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
+        }
+        if (claim.getStatus() != Claim.ClaimStatus.IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
+        }
     }
 
     private void validateSellerClaimOwnership(Claim claim, Long memberId) {

--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImpl.java
@@ -259,11 +259,8 @@ public class ClaimServiceImpl implements ClaimService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CLAIM_NOT_FOUND));
 
         validateSellerClaimOwnership(claim, memberId);
-        validateRejectableStatus(claim);
 
-        claim.reject(request.getRejectReason());
-        logger.info("[ClaimService] 판매자 클레임 거부 - claimId: {}, memberId: {}", claimId, memberId);
-        return ClaimResponseDto.from(claim);
+        throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
     }
 
     private void validateAdminRejectableStatus(Claim claim) {
@@ -285,8 +282,9 @@ public class ClaimServiceImpl implements ClaimService {
     }
 
     private void validateSellerClaimOwnership(Claim claim, Long memberId) {
-        // 판매자 등록 여부 먼저 확인
-        if (!sellerRepository.existsByMemberIdAndDeletedAtIsNull(memberId)) {
+        Seller seller = sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_SELLER));
+        if (seller.getStatus() != SellerStatus.APPROVED) {
             throw new BusinessException(ErrorCode.NOT_SELLER);
         }
 
@@ -296,18 +294,6 @@ public class ClaimServiceImpl implements ClaimService {
         Long productOwnerMemberId = orderItem.getProduct().getSeller().getMember().getId();
         if (!productOwnerMemberId.equals(memberId)) {
             throw new BusinessException(ErrorCode.CLAIM_UNAUTHORIZED);
-        }
-    }
-
-    private void validateRejectableStatus(Claim claim) {
-        if (claim.getStatus() == Claim.ClaimStatus.COMPLETED) {
-            throw new BusinessException(ErrorCode.CLAIM_ALREADY_COMPLETED);
-        }
-        if (claim.getStatus() == Claim.ClaimStatus.CANCELLED) {
-            throw new BusinessException(ErrorCode.CLAIM_ALREADY_CANCELLED);
-        }
-        if (claim.getStatus() == Claim.ClaimStatus.REJECTED) {
-            throw new BusinessException(ErrorCode.CLAIM_INVALID_STATUS);
         }
     }
 

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import co.kr.allpick.domain.seller.entity.Seller;
+import co.kr.allpick.domain.seller.entity.SellerStatus;
 import co.kr.allpick.domain.seller.repository.SellerRepository;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -537,12 +538,32 @@ class ClaimServiceImplTest {
         Claim mockClaim = buildMockClaim();
 
         given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
-        given(sellerRepository.existsByMemberIdAndDeletedAtIsNull(memberId)).willReturn(false);
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> claimService.approveClaim(claimId, memberId))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.NOT_SELLER.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_SELLER);
+    }
+
+    @Test
+    @DisplayName("클레임 승인 실패 - 승인되지 않은 판매자")
+    void approveClaim_notApprovedSeller_throwException() {
+        // given
+        Long claimId = 1L;
+        Long memberId = 1L;
+        Claim mockClaim = buildMockClaim();
+        Seller pendingSeller = Seller.builder()
+                .status(SellerStatus.PENDING)
+                .build();
+
+        given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(pendingSeller));
+
+        // when & then
+        assertThatThrownBy(() -> claimService.approveClaim(claimId, memberId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_SELLER);
     }
 
     @Test
@@ -558,17 +579,52 @@ class ClaimServiceImplTest {
         Member mockMember = mock(Member.class);
         given(mockMember.getId()).willReturn(memberId);
 
-        Seller mockSeller = Seller.builder().member(mockMember).build();
+        Seller mockSeller = Seller.builder()
+                .member(mockMember)
+                .status(SellerStatus.APPROVED)
+                .build();
         OrderItem mockOrderItem = mock(OrderItem.class);
         Product mockProduct = mock(Product.class);
         given(mockProduct.getSeller()).willReturn(mockSeller);
         given(mockOrderItem.getProduct()).willReturn(mockProduct);
 
         given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
-        given(sellerRepository.existsByMemberIdAndDeletedAtIsNull(memberId)).willReturn(true);
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(mockSeller));
         given(orderItemRepository.findByIdWithSellerMember(orderItemId)).willReturn(Optional.of(mockOrderItem));
 
         // when & then
         claimService.approveClaim(claimId, memberId);
+    }
+
+    @Test
+    @DisplayName("클레임 거부 실패 - 판매자 최종 거부 미지원")
+    void rejectClaimBySeller_throwException() {
+        // given
+        Long claimId = 1L;
+        Long memberId = 1L;
+        Long orderItemId = 10L;
+        Claim mockClaim = buildMockClaim();
+        ClaimRejectRequestDto request = new ClaimRejectRequestDto("거부 사유");
+
+        Member mockMember = mock(Member.class);
+        given(mockMember.getId()).willReturn(memberId);
+
+        Seller mockSeller = Seller.builder()
+                .member(mockMember)
+                .status(SellerStatus.APPROVED)
+                .build();
+        OrderItem mockOrderItem = mock(OrderItem.class);
+        Product mockProduct = mock(Product.class);
+        given(mockProduct.getSeller()).willReturn(mockSeller);
+        given(mockOrderItem.getProduct()).willReturn(mockProduct);
+
+        given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)).willReturn(Optional.of(mockSeller));
+        given(orderItemRepository.findByIdWithSellerMember(orderItemId)).willReturn(Optional.of(mockOrderItem));
+
+        // when & then
+        assertThatThrownBy(() -> claimService.rejectClaimBySeller(claimId, request, memberId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLAIM_INVALID_STATUS);
     }
 }

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/ClaimServiceImplTest.java
@@ -408,8 +408,29 @@ class ClaimServiceImplTest {
     }
 
     @Test
-    @DisplayName("클레임 상태 변경 성공")
+    @DisplayName("클레임 상태 변경 성공 - 판매자 확인 후 관리자 완료")
     void 클레임_상태_변경_성공() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo(1L);
+        Long claimId = 1L;
+        Claim mockClaim = buildMockClaim();
+        mockClaim.updateStatus(Claim.ClaimStatus.IN_PROGRESS);
+        ClaimStatusUpdateRequestDto request = new ClaimStatusUpdateRequestDto(Claim.ClaimStatus.COMPLETED);
+
+        given(adminRepository.findById(adminInfo.getAdminId()))
+                .willReturn(Optional.of(buildAdmin(Admin.AdminRole.SUPER_ADMIN, Admin.AdminStatus.ACTIVE)));
+        given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
+
+        // when
+        ClaimResponseDto result = claimService.updateStatus(adminInfo, claimId, request);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(Claim.ClaimStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("클레임 상태 변경 실패 - 판매자 확인 전 관리자 직접 처리")
+    void 클레임_상태_변경_실패_판매자확인전() {
         // given
         AdminJwtUserInfoDto adminInfo = superAdminInfo(1L);
         Long claimId = 1L;
@@ -420,11 +441,10 @@ class ClaimServiceImplTest {
                 .willReturn(Optional.of(buildAdmin(Admin.AdminRole.SUPER_ADMIN, Admin.AdminStatus.ACTIVE)));
         given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
 
-        // when
-        ClaimResponseDto result = claimService.updateStatus(adminInfo, claimId, request);
-
-        // then
-        assertThat(result.getStatus()).isEqualTo(Claim.ClaimStatus.IN_PROGRESS);
+        // when & then
+        assertThatThrownBy(() -> claimService.updateStatus(adminInfo, claimId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLAIM_INVALID_STATUS);
     }
 
     @Test
@@ -444,7 +464,7 @@ class ClaimServiceImplTest {
         // when & then
         assertThatThrownBy(() -> claimService.updateStatus(adminInfo, claimId, request))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.CLAIM_INVALID_STATUS.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLAIM_INVALID_STATUS);
     }
 
     @Test
@@ -454,6 +474,7 @@ class ClaimServiceImplTest {
         AdminJwtUserInfoDto adminInfo = superAdminInfo(1L);
         Long claimId = 1L;
         Claim mockClaim = buildMockClaim();
+        mockClaim.updateStatus(Claim.ClaimStatus.IN_PROGRESS);
         ClaimRejectRequestDto request = new ClaimRejectRequestDto("사유");
 
         given(adminRepository.findById(adminInfo.getAdminId()))
@@ -465,6 +486,25 @@ class ClaimServiceImplTest {
 
         // then
         assertThat(result.getStatus()).isEqualTo(Claim.ClaimStatus.REJECTED);
+    }
+
+    @Test
+    @DisplayName("클레임 거부 실패 - 판매자 확인 전 관리자 직접 거부")
+    void 클레임_거부_실패_판매자확인전() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo(1L);
+        Long claimId = 1L;
+        Claim mockClaim = buildMockClaim();
+        ClaimRejectRequestDto request = new ClaimRejectRequestDto("거부 사유");
+
+        given(adminRepository.findById(adminInfo.getAdminId()))
+                .willReturn(Optional.of(buildAdmin(Admin.AdminRole.SUPER_ADMIN, Admin.AdminStatus.ACTIVE)));
+        given(claimRepository.findById(claimId)).willReturn(Optional.of(mockClaim));
+
+        // when & then
+        assertThatThrownBy(() -> claimService.rejectClaim(adminInfo, claimId, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLAIM_INVALID_STATUS);
     }
 
     @Test
@@ -484,7 +524,7 @@ class ClaimServiceImplTest {
         // when & then
         assertThatThrownBy(() -> claimService.rejectClaim(adminInfo, claimId, request))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.CLAIM_ALREADY_CANCELLED.getMessage());
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLAIM_ALREADY_CANCELLED);
     }
     
     @Test


### PR DESCRIPTION
﻿## 개요
- 클레임 처리 API가 사용자 요청 → 판매자 확인 → 관리자 최종 처리 흐름을 건너뛰지 못하도록 상태와 판매자 권한 검증을 강화했습니다.

---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [x] 문서 수정

### 주요 변경 사항
- Controller: `ClaimControllerDocs`에서 관리자/판매자 클레임 처리 역할 설명 수정
- Service:
  - 관리자 상태 변경은 `IN_PROGRESS → COMPLETED`만 허용하도록 제한
  - 관리자 거절은 `IN_PROGRESS` 상태에서만 가능하도록 검증 추가
  - 판매자 클레임 승인/거절 액션에서 `APPROVED` 판매자인지 검증 추가
  - 판매자 최종 거절은 지원하지 않도록 `CLAIM_INVALID_STATUS`로 차단
- Repository: 변경 없음
- 기타:
  - `ClaimStatusUpdateRequestDto` Swagger 예시를 관리자 완료 처리 기준으로 수정
  - `ClaimServiceImplTest`에 판매자 확인 전 관리자 직접 처리 실패, 승인되지 않은 판매자 처리 실패, 판매자 최종 거절 실패 케이스 추가

---

## 관련 이슈
- 관련 이슈: s4ngg/AP-React#173

---

## 변경 전 / 후
### Before
- 관리자가 `SUBMITTED` 상태의 환불 요청을 바로 `IN_PROGRESS`로 변경할 수 있었습니다.
- 관리자가 판매자 확인 전 환불 요청을 바로 거절할 수 있었습니다.
- 판매자가 `SUBMITTED` 클레임을 바로 `REJECTED`로 만들 수 있었습니다.
- 정지/미승인 판매자가 claimId를 알고 있으면 처리 액션을 시도할 수 있었습니다.

### After
- 판매자가 승인해 `IN_PROGRESS`가 된 클레임만 관리자가 최종 승인(`COMPLETED`)할 수 있습니다.
- 판매자가 확인하기 전인 `SUBMITTED` 클레임은 관리자 거절도 불가능합니다.
- 판매자는 클레임을 최종 거절할 수 없고, 관리자 최종 처리 단계로 넘기는 승인만 가능합니다.
- 승인된 판매자(`APPROVED`)만 클레임 처리 액션을 수행할 수 있습니다.
- 사용자 환불 요청 → 판매자 확인 → 관리자 최종 처리 흐름을 백엔드 서비스 레벨에서 보장합니다.

---

## 검증
- `./gradlew.bat test --tests co.kr.allpick.domain.admin.product.service.impl.ClaimServiceImplTest`
- `./gradlew.bat compileJava`
