### PR TITLE
fix: 관리자 카테고리 정렬 번호 중복 검증

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/category/dto/AdminCategoryRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/dto/AdminCategoryRequestDto.java
@@ -26,7 +26,7 @@ public class AdminCategoryRequestDto {
     private String slug;
 
     @NotNull(message = "정렬 순서는 필수입니다.")
-    @Min(value = 0, message = "정렬 순서는 0 이상이어야 합니다.")
+    @Min(value = 1, message = "정렬 순서는 1 이상이어야 합니다.")
     @Schema(description = "정렬 순서", example = "1")
     private Integer sortOrder;
 

--- a/src/main/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImpl.java
@@ -48,6 +48,7 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
     public ParentCategoryResponseDto createParentCategory(AdminJwtUserInfoDto adminInfo, AdminCategoryRequestDto request) {
         Admin admin = getSuperAdmin(adminInfo);
         validateSlugForCreate(request.getSlug());
+        validateParentSortOrderForCreate(request.getSortOrder());
 
         ParentCategory parentCategory = parentCategoryRepository.save(ParentCategory.builder()
                 .categoryName(request.getCategoryName().trim())
@@ -71,6 +72,7 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
         Admin admin = getSuperAdmin(adminInfo);
         ParentCategory parentCategory = getParentCategory(parentCategoryId);
         validateSlugForUpdate(request.getSlug(), parentCategory.getSlug());
+        validateParentSortOrderForUpdate(parentCategoryId, request.getSortOrder());
 
         parentCategory.update(
                 request.getCategoryName().trim(),
@@ -120,6 +122,7 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
         Admin admin = getSuperAdmin(adminInfo);
         ParentCategory parentCategory = getParentCategory(parentCategoryId);
         validateSlugForCreate(request.getSlug());
+        validateChildSortOrderForCreate(parentCategoryId, request.getSortOrder());
 
         ChildCategory childCategory = childCategoryRepository.save(ChildCategory.builder()
                 .parentCategory(parentCategory)
@@ -145,6 +148,7 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
         ChildCategory childCategory = getChildCategory(childCategoryId);
         ParentCategory parentCategory = childCategory.getParentCategory();
         validateSlugForUpdate(request.getSlug(), childCategory.getSlug());
+        validateChildSortOrderForUpdate(parentCategory.getParentCategoryId(), childCategoryId, request.getSortOrder());
 
         childCategory.update(
                 parentCategory,
@@ -210,5 +214,32 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
     private boolean isSlugDuplicated(String slug) {
         return parentCategoryRepository.existsBySlugAndDeletedAtIsNull(slug.trim())
                 || childCategoryRepository.existsBySlugAndDeletedAtIsNull(slug.trim());
+    }
+
+    private void validateParentSortOrderForCreate(Integer sortOrder) {
+        if (parentCategoryRepository.existsBySortOrderAndDeletedAtIsNull(sortOrder)) {
+            throw new BusinessException(ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        }
+    }
+
+    private void validateParentSortOrderForUpdate(Long parentCategoryId, Integer sortOrder) {
+        if (parentCategoryRepository.existsBySortOrderAndParentCategoryIdNotAndDeletedAtIsNull(
+                sortOrder, parentCategoryId)) {
+            throw new BusinessException(ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        }
+    }
+
+    private void validateChildSortOrderForCreate(Long parentCategoryId, Integer sortOrder) {
+        if (childCategoryRepository.existsByParentCategory_ParentCategoryIdAndSortOrderAndDeletedAtIsNull(
+                parentCategoryId, sortOrder)) {
+            throw new BusinessException(ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        }
+    }
+
+    private void validateChildSortOrderForUpdate(Long parentCategoryId, Long childCategoryId, Integer sortOrder) {
+        if (childCategoryRepository.existsByParentCategory_ParentCategoryIdAndSortOrderAndChildCategoryIdNotAndDeletedAtIsNull(
+                parentCategoryId, sortOrder, childCategoryId)) {
+            throw new BusinessException(ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        }
     }
 }

--- a/src/main/java/co/kr/allpick/domain/product/repository/ChildCategoryRepository.java
+++ b/src/main/java/co/kr/allpick/domain/product/repository/ChildCategoryRepository.java
@@ -28,4 +28,10 @@ public interface ChildCategoryRepository extends JpaRepository<ChildCategory, Lo
     Optional<ChildCategory> findByChildCategoryIdAndDeletedAtIsNull(Long childCategoryId);
 
     boolean existsBySlugAndDeletedAtIsNull(String slug);
+
+    boolean existsByParentCategory_ParentCategoryIdAndSortOrderAndDeletedAtIsNull(
+            Long parentCategoryId, Integer sortOrder);
+
+    boolean existsByParentCategory_ParentCategoryIdAndSortOrderAndChildCategoryIdNotAndDeletedAtIsNull(
+            Long parentCategoryId, Integer sortOrder, Long childCategoryId);
 }

--- a/src/main/java/co/kr/allpick/domain/product/repository/ParentCategoryRepository.java
+++ b/src/main/java/co/kr/allpick/domain/product/repository/ParentCategoryRepository.java
@@ -27,4 +27,8 @@ public interface ParentCategoryRepository extends JpaRepository<ParentCategory, 
 
     boolean existsBySlugAndDeletedAtIsNull(String slug);
 
+    boolean existsBySortOrderAndDeletedAtIsNull(Integer sortOrder);
+
+    boolean existsBySortOrderAndParentCategoryIdNotAndDeletedAtIsNull(Integer sortOrder, Long parentCategoryId);
+
 }

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -111,6 +111,7 @@ public enum ErrorCode {
     // Category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
     CATEGORY_SLUG_DUPLICATED(HttpStatus.CONFLICT, "CATEGORY_SLUG_DUPLICATED", "이미 사용 중인 카테고리 URL입니다."),
+    CATEGORY_SORT_ORDER_DUPLICATED(HttpStatus.CONFLICT, "CATEGORY_SORT_ORDER_DUPLICATED", "이미 사용 중인 정렬 번호입니다."),
 
     // image
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_UPLOAD_FAILED", "이미지 업로드에 실패했습니다."),

--- a/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/category/service/impl/AdminCategoryServiceImplTest.java
@@ -112,6 +112,25 @@ class AdminCategoryServiceImplTest {
     }
 
     @Test
+    @DisplayName("대분류 등록 실패 - 정렬 번호 중복")
+    void 대분류_등록_실패_정렬번호중복() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        AdminCategoryRequestDto request = request("뷰티", "beauty", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("beauty")).willReturn(false);
+        given(parentCategoryRepository.existsBySortOrderAndDeletedAtIsNull(1)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.createParentCategory(adminInfo, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        verify(parentCategoryRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("대분류 수정 성공")
     void 대분류_수정_성공() {
         // given
@@ -133,6 +152,49 @@ class AdminCategoryServiceImplTest {
         assertThat(parentCategory.getSlug()).isEqualTo("beauty-zone");
         assertThat(parentCategory.getSortOrder()).isEqualTo(2);
         assertThat(parentCategory.getIsActive()).isZero();
+    }
+
+    @Test
+    @DisplayName("대분류 수정 성공 - 기존 정렬 번호 유지")
+    void 대분류_수정_성공_기존정렬번호유지() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        AdminCategoryRequestDto request = request("뷰티관", "beauty", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+        given(parentCategoryRepository.existsBySortOrderAndParentCategoryIdNotAndDeletedAtIsNull(1, 1L))
+                .willReturn(false);
+
+        // when
+        ParentCategoryResponseDto result = adminCategoryService.updateParentCategory(adminInfo, 1L, request);
+
+        // then
+        assertThat(result.getCategoryName()).isEqualTo("뷰티관");
+        assertThat(parentCategory.getSortOrder()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("대분류 수정 실패 - 정렬 번호 중복")
+    void 대분류_수정_실패_정렬번호중복() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        AdminCategoryRequestDto request = request("뷰티관", "beauty", 2, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+        given(parentCategoryRepository.existsBySortOrderAndParentCategoryIdNotAndDeletedAtIsNull(2, 1L))
+                .willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.updateParentCategory(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        assertThat(parentCategory.getSortOrder()).isEqualTo(1);
     }
 
     @Test
@@ -296,6 +358,29 @@ class AdminCategoryServiceImplTest {
     }
 
     @Test
+    @DisplayName("소분류 등록 실패 - 같은 대분류 안 정렬 번호 중복")
+    void 소분류_등록_실패_같은대분류정렬번호중복() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        AdminCategoryRequestDto request = request("스킨케어", "skincare", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(parentCategoryRepository.findByParentCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(parentCategory));
+        given(parentCategoryRepository.existsBySlugAndDeletedAtIsNull("skincare")).willReturn(false);
+        given(childCategoryRepository.existsBySlugAndDeletedAtIsNull("skincare")).willReturn(false);
+        given(childCategoryRepository.existsByParentCategory_ParentCategoryIdAndSortOrderAndDeletedAtIsNull(1L, 1))
+                .willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.createChildCategory(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        verify(childCategoryRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("소분류 등록 실패 - 부모 카테고리 없음")
     void 소분류_등록_실패_부모카테고리없음() {
         // given
@@ -336,6 +421,51 @@ class AdminCategoryServiceImplTest {
         assertThat(childCategory.getParentCategory()).isEqualTo(parentCategory);
         assertThat(childCategory.getSlug()).isEqualTo("basic-cosmetic");
         assertThat(childCategory.getIsActive()).isZero();
+    }
+
+    @Test
+    @DisplayName("소분류 수정 성공 - 기존 정렬 번호 유지")
+    void 소분류_수정_성공_기존정렬번호유지() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        ChildCategory childCategory = childCategory(1L, parentCategory, "스킨케어", "skincare", 1, 1);
+        AdminCategoryRequestDto request = request("스킨케어", "skincare", 1, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(childCategoryRepository.findByChildCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(childCategory));
+        given(childCategoryRepository.existsByParentCategory_ParentCategoryIdAndSortOrderAndChildCategoryIdNotAndDeletedAtIsNull(
+                1L, 1, 1L)).willReturn(false);
+
+        // when
+        ChildCategoryResponseDto result = adminCategoryService.updateChildCategory(adminInfo, 1L, request);
+
+        // then
+        assertThat(result.getCategoryName()).isEqualTo("스킨케어");
+        assertThat(childCategory.getSortOrder()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("소분류 수정 실패 - 같은 대분류 안 정렬 번호 중복")
+    void 소분류_수정_실패_같은대분류정렬번호중복() {
+        // given
+        AdminJwtUserInfoDto adminInfo = superAdminInfo();
+        ParentCategory parentCategory = parentCategory(1L, "뷰티", "beauty", 1, 1);
+        ChildCategory childCategory = childCategory(1L, parentCategory, "스킨케어", "skincare", 1, 1);
+        AdminCategoryRequestDto request = request("스킨케어", "skincare", 2, 1);
+
+        given(adminRepository.findById(adminInfo.getAdminId())).willReturn(Optional.of(superAdmin()));
+        given(childCategoryRepository.findByChildCategoryIdAndDeletedAtIsNull(1L))
+                .willReturn(Optional.of(childCategory));
+        given(childCategoryRepository.existsByParentCategory_ParentCategoryIdAndSortOrderAndChildCategoryIdNotAndDeletedAtIsNull(
+                1L, 2, 1L)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminCategoryService.updateChildCategory(adminInfo, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_SORT_ORDER_DUPLICATED);
+        assertThat(childCategory.getSortOrder()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
﻿## 개요
- 관리자 카테고리 정렬 번호가 중복 등록/수정되지 않도록 백엔드 검증을 추가했습니다.

---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller:
  - 기존 `@Valid` 요청 검증 흐름 유지
- Service:
  - 대분류 등록/수정 시 삭제되지 않은 대분류 전체 기준 `sortOrder` 중복 검증 추가
  - 소분류 등록/수정 시 같은 대분류 안에서 `sortOrder` 중복 검증 추가
  - 수정 시 자기 자신의 기존 정렬 번호는 허용
- Repository:
  - 대분류/소분류 정렬 번호 중복 확인용 exists 메서드 추가
- 기타:
  - `CATEGORY_SORT_ORDER_DUPLICATED` ErrorCode 추가
  - `sortOrder` 최소값을 0에서 1로 변경
  - 관리자 카테고리 서비스 테스트 보강

---

## 관련 이슈
- 관련 이슈: 카테고리 관리 정렬 번호 중복 등록 방지

---

## 변경 전 / 후
### Before
- 같은 정렬 번호를 가진 카테고리를 등록하거나 수정할 수 있었습니다.
- `sortOrder ASC`만으로 정렬되기 때문에 같은 번호끼리는 노출 순서가 불안정할 수 있었습니다.

### After
- 대분류는 삭제되지 않은 대분류 전체 기준으로 정렬 번호 중복을 차단합니다.
- 소분류는 같은 대분류 안에서 정렬 번호 중복을 차단합니다.
- 중복 시 `CATEGORY_SORT_ORDER_DUPLICATED`로 명확하게 응답합니다.

---

## 검증
- [x] `./gradlew.bat compileJava`
- [ ] `./gradlew.bat test --tests "co.kr.allpick.domain.admin.category.service.impl.AdminCategoryServiceImplTest"`

### 참고
- 테스트 실행은 `compileTestJava` 단계에서 기존 `InquiryServiceImplTest`가 최신 `InquiryRepository` 메서드명과 맞지 않아 실패합니다.
- 실패 메서드: `findByMemberIdAndDeletedAtIsNull`, `findAllByDeletedAtIsNull`
- 카테고리 변경 코드의 `compileJava`는 성공했습니다.
