### PR TITLE
feat: 상품 카테고리 구조를 parentCategory에서 childCategory로 변경

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/dto/AdminProductListResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/dto/AdminProductListResponseDto.java
@@ -46,8 +46,8 @@ public class AdminProductListResponseDto {
     public static AdminProductListResponseDto from(Product product) {
         return AdminProductListResponseDto.builder()
                 .productId(product.getProductId())
-                .parentCategoryName(product.getParentCategory() != null
-                        ? product.getParentCategory().getCategoryName()
+                .parentCategoryName(product.getChildCategory() != null && product.getChildCategory().getParentCategory() != null
+                        ? product.getChildCategory().getParentCategory().getCategoryName()
                         : null)
                 .brand(product.getBrand())
                 .productName(product.getProductName())

--- a/src/main/java/co/kr/allpick/domain/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/product/dto/ProductDetailResponseDto.java
@@ -69,8 +69,8 @@ public class ProductDetailResponseDto {
 	public static ProductDetailResponseDto from(Product product, Page<ReviewResponseDto> reviewList) {
 		return ProductDetailResponseDto.builder()
 				.productId(product.getProductId())
-				.parentCategoryName(product.getParentCategory() != null ?
-						product.getParentCategory().getCategoryName() : "미분류")
+				.parentCategoryName(product.getChildCategory() != null && product.getChildCategory().getParentCategory() != null ?
+						product.getChildCategory().getParentCategory().getCategoryName() : "미분류")
 				.brand(product.getBrand())
 				.productName(product.getProductName())
 				.thumbnailUrl(product.getThumbnailUrl())

--- a/src/main/java/co/kr/allpick/domain/product/dto/ProductListResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/product/dto/ProductListResponseDto.java
@@ -15,8 +15,11 @@ public class ProductListResponseDto {
     @Schema(description = "상품 ID", example = "1")
     private Long productId;
 
-    @Schema(description = "카테고리명", example = "뷰티")
+    @Schema(description = "부모 카테고리명", example = "패션")
     private String parentCategoryName;
+
+    @Schema(description = "자식 카테고리명", example = "신발")
+    private String childCategoryName;
 
     @Schema(description = "브랜드명", example = "나이키")
     private String brand;
@@ -33,8 +36,10 @@ public class ProductListResponseDto {
     public static ProductListResponseDto from(Product product) {
         return ProductListResponseDto.builder()
                 .productId(product.getProductId())
-                .parentCategoryName(product.getParentCategory() !=null
-                        ? product.getParentCategory().getCategoryName() : null)
+                .parentCategoryName(product.getChildCategory() != null && product.getChildCategory().getParentCategory() != null
+                        ? product.getChildCategory().getParentCategory().getCategoryName() : null)
+                .childCategoryName(product.getChildCategory() != null
+                        ? product.getChildCategory().getCategoryName() : null)
                 .brand(product.getBrand())
                 .productName(product.getProductName())
                 .thumbnailUrl(product.getThumbnailUrl())

--- a/src/main/java/co/kr/allpick/domain/product/dto/ProductSaveRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/product/dto/ProductSaveRequestDto.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import co.kr.allpick.domain.product.entity.ParentCategory;
+import co.kr.allpick.domain.product.entity.ChildCategory;
 import co.kr.allpick.domain.product.entity.Product;
 import co.kr.allpick.domain.product.entity.ProductImage;
 import co.kr.allpick.domain.product.entity.ProductOption;
@@ -71,10 +71,10 @@ public class ProductSaveRequestDto {
 		
 		
 		@Schema(description = "상품객체 생성 메서드")
-		public Product toEntity(Seller seller, ParentCategory parentCategory) {
+		public Product toEntity(Seller seller, ChildCategory childCategory) {
 			Product product = Product.builder()
 						.seller(seller)
-						.parentCategory(parentCategory)	
+						.childCategory(childCategory)
 						.productName(this.productName)
 						.brand(this.brand)
 						.thumbnailUrl(this.thumbnailUrl)

--- a/src/main/java/co/kr/allpick/domain/product/dto/SellerProductListResponseDto.java
+++ b/src/main/java/co/kr/allpick/domain/product/dto/SellerProductListResponseDto.java
@@ -36,8 +36,8 @@ public class SellerProductListResponseDto {
     public static SellerProductListResponseDto from(Product product) {
         return SellerProductListResponseDto.builder()
                 .productId(product.getProductId())
-                .parentCategoryName(product.getParentCategory() != null
-                        ? product.getParentCategory().getCategoryName() : null)
+                .parentCategoryName(product.getChildCategory() != null && product.getChildCategory().getParentCategory() != null
+                        ? product.getChildCategory().getParentCategory().getCategoryName() : null)
                 .brand(product.getBrand())
                 .productName(product.getProductName())
                 .thumbnailUrl(product.getThumbnailUrl())

--- a/src/main/java/co/kr/allpick/domain/product/entity/Product.java
+++ b/src/main/java/co/kr/allpick/domain/product/entity/Product.java
@@ -51,8 +51,8 @@ public class Product extends BaseEntity {
     private Seller seller;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_category_id", nullable = false)
-    private ParentCategory parentCategory;
+    @JoinColumn(name = "child_category_id", nullable = false)
+    private ChildCategory childCategory;
 
     @BatchSize(size = 100)
     @Builder.Default

--- a/src/main/java/co/kr/allpick/domain/product/repository/ProductRepository.java
+++ b/src/main/java/co/kr/allpick/domain/product/repository/ProductRepository.java
@@ -18,7 +18,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     // 상품 상세 조회 - 판매중, 승인된, 삭제 안 된 상품만
     @Query("SELECT p FROM Product p " +
-           "LEFT JOIN FETCH p.parentCategory " +
+           "LEFT JOIN FETCH p.childCategory c " +
+           "LEFT JOIN FETCH c.parentCategory " +
            "JOIN FETCH p.seller s " +
            "JOIN s.member m " +
            "WHERE p.productId = :id " +
@@ -56,11 +57,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findBySellerIdAndDeletedAtIsNull(@Param("sellerId") Long sellerId);
 
     // 관리자 상품 목록 조회
-    @EntityGraph(attributePaths = {"parentCategory", "optionList", "seller"})
+    @EntityGraph(attributePaths = {"childCategory", "childCategory.parentCategory", "optionList", "seller"})
     List<Product> findAllByDeletedAtIsNullOrderByCreatedAtDesc();
 
     // 판매 중이고 승인된 상품 목록 페이지 조회
-    @EntityGraph(attributePaths = {"parentCategory"})
+    @EntityGraph(attributePaths = {"childCategory", "childCategory.parentCategory"})
     @Query("SELECT p FROM Product p " +
            "JOIN p.seller s " +
            "JOIN s.member m " +

--- a/src/main/java/co/kr/allpick/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/product/service/impl/ProductServiceImpl.java
@@ -16,9 +16,9 @@ import co.kr.allpick.domain.product.dto.ProductSaveResponseDto;
 import co.kr.allpick.domain.product.dto.ProductUpdateRequestDto;
 import co.kr.allpick.domain.product.dto.ProductUpdateResponseDto;
 import co.kr.allpick.domain.product.dto.SellerProductListResponseDto;
-import co.kr.allpick.domain.product.entity.ParentCategory;
+import co.kr.allpick.domain.product.entity.ChildCategory;
 import co.kr.allpick.domain.product.entity.Product;
-import co.kr.allpick.domain.product.repository.ParentCategoryRepository;
+import co.kr.allpick.domain.product.repository.ChildCategoryRepository;
 import co.kr.allpick.domain.product.repository.ProductRepository;
 import co.kr.allpick.domain.product.service.ProductService;
 import co.kr.allpick.domain.review.dto.ReviewResponseDto;
@@ -37,7 +37,7 @@ public class ProductServiceImpl implements ProductService {
     private static final Logger logger = LogManager.getLogger(ProductServiceImpl.class);
 
     private final ProductRepository productRepository;
-    private final ParentCategoryRepository parentCategoryRepository;
+    private final ChildCategoryRepository childCategoryRepository;
     private final ReviewRepository reviewRepository;
     private final SellerRepository sellerRepository;
 
@@ -45,12 +45,12 @@ public class ProductServiceImpl implements ProductService {
     public ProductSaveResponseDto createProduct(Long memberId, ProductSaveRequestDto reqDto) {
         Seller seller = sellerRepository.findWithMemberByMemberId(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_SELLER));
-        ParentCategory parentCategory = parentCategoryRepository.findById(reqDto.getCategoryId())
+        ChildCategory childCategory = childCategoryRepository.findById(reqDto.getCategoryId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
         if (productRepository.existsByProductName(reqDto.getProductName())) {
             throw new BusinessException(ErrorCode.PRODUCT_ALREADY_EXISTS);
         }
-        Product product = reqDto.toEntity(seller, parentCategory);
+        Product product = reqDto.toEntity(seller, childCategory);
         productRepository.save(product);
         return ProductSaveResponseDto.from(product);
     }

--- a/src/test/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImplTest.java
@@ -194,7 +194,7 @@ class InquiryServiceImplTest {
                 .content("결제 관련 내용")
                 .build();
 
-        when(inquiryRepository.findByMemberIdAndDeletedAtIsNull(memberId))
+        when(inquiryRepository.findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(memberId))
                 .thenReturn(List.of(mockInquiry1, mockInquiry2));
         when(inquiryAnswerRepository.findByInquiryId(any())).thenReturn(List.of());
 
@@ -218,7 +218,7 @@ class InquiryServiceImplTest {
                 .content("기타 내용")
                 .build();
 
-        when(inquiryRepository.findAllByDeletedAtIsNull()).thenReturn(List.of(mockInquiry));
+        when(inquiryRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc()).thenReturn(List.of(mockInquiry));
         when(inquiryAnswerRepository.findByInquiryId(any())).thenReturn(List.of());
 
         // when

--- a/src/test/java/co/kr/allpick/domain/product/service/impl/ProductServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/product/service/impl/ProductServiceImplTest.java
@@ -34,9 +34,10 @@ import co.kr.allpick.domain.product.dto.ProductSaveResponseDto;
 import co.kr.allpick.domain.product.dto.ProductUpdateRequestDto;
 import co.kr.allpick.domain.product.dto.ProductUpdateResponseDto;
 import co.kr.allpick.domain.product.dto.SellerProductListResponseDto;
+import co.kr.allpick.domain.product.entity.ChildCategory;
 import co.kr.allpick.domain.product.entity.ParentCategory;
 import co.kr.allpick.domain.product.entity.Product;
-import co.kr.allpick.domain.product.repository.ParentCategoryRepository;
+import co.kr.allpick.domain.product.repository.ChildCategoryRepository;
 import co.kr.allpick.domain.product.repository.ProductRepository;
 import co.kr.allpick.domain.review.entity.Review;
 import co.kr.allpick.domain.review.repository.ReviewRepository;
@@ -52,7 +53,7 @@ class ProductServiceImplTest {
     private ProductRepository productRepository;
 
     @Mock
-    private ParentCategoryRepository parentCategoryRepository;
+    private ChildCategoryRepository childCategoryRepository;
 
     @Mock
     private ReviewRepository reviewRepository;
@@ -71,11 +72,12 @@ class ProductServiceImplTest {
         Long productId = 1L;
         Pageable pageable = PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        ParentCategory mockCategory = ParentCategory.builder().categoryName("전통주").build();
+        ParentCategory mockParent = ParentCategory.builder().categoryName("전통주").build();
+        ChildCategory mockCategory = ChildCategory.builder().categoryName("막걸리").parentCategory(mockParent).build();
 
         Product mockProduct = Product.builder()
                 .productId(productId)
-                .parentCategory(mockCategory)
+                .childCategory(mockCategory)
                 .productName("느린마을 막걸리")
                 .brand("배상면주가")
                 .price(new BigDecimal("10000"))
@@ -121,8 +123,8 @@ class ProductServiceImplTest {
 
         Seller mockSeller = Seller.builder().build(); 
 
-        ParentCategory mockCategory = ParentCategory.builder()
-                .parentCategoryId(categoryId)
+        ChildCategory mockCategory = ChildCategory.builder()
+                .childCategoryId(categoryId)
                 .categoryName("전통주")
                 .build();
 
@@ -135,11 +137,11 @@ class ProductServiceImplTest {
 
         Product mockProduct = Product.builder()
                 .productName(reqDto.getProductName())
-                .parentCategory(mockCategory)
+                .childCategory(mockCategory)
                 .build();
 
         when(sellerRepository.findWithMemberByMemberId(memberId)).thenReturn(Optional.of(mockSeller));
-        when(parentCategoryRepository.findById(categoryId)).thenReturn(Optional.of(mockCategory));
+        when(childCategoryRepository.findById(categoryId)).thenReturn(Optional.of(mockCategory));
         when(productRepository.existsByProductName(reqDto.getProductName())).thenReturn(false);
         when(productRepository.save(any(Product.class))).thenReturn(mockProduct);
 
@@ -176,7 +178,7 @@ class ProductServiceImplTest {
                 .build();
 
         when(sellerRepository.findWithMemberByMemberId(memberId)).thenReturn(Optional.of(Seller.builder().build()));
-        when(parentCategoryRepository.findById(anyLong())).thenReturn(Optional.of(mock(ParentCategory.class)));
+        when(childCategoryRepository.findById(anyLong())).thenReturn(Optional.of(mock(ChildCategory.class)));
         when(productRepository.existsByProductName("이미있는상품")).thenReturn(true);
 
         assertThatThrownBy(() -> productService.createProduct(memberId, reqDto)) // ✅ memberId 추가
@@ -193,7 +195,7 @@ class ProductServiceImplTest {
                 .build();
 
         when(sellerRepository.findWithMemberByMemberId(memberId)).thenReturn(Optional.of(Seller.builder().build()));
-        when(parentCategoryRepository.findById(999L)).thenReturn(Optional.empty());
+        when(childCategoryRepository.findById(999L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> productService.createProduct(memberId, reqDto))
                 .isInstanceOf(BusinessException.class)
@@ -205,16 +207,15 @@ class ProductServiceImplTest {
     @Test
     @DisplayName("상품 목록 조회 성공")
     void 상품_목록_조회_성공() {
-        ParentCategory mockCategory = ParentCategory.builder()
-                .categoryName("뷰티")
-                .build();
+        ParentCategory mockParent = ParentCategory.builder().categoryName("뷰티").build();
+        ChildCategory mockCategory = ChildCategory.builder().categoryName("스킨케어").parentCategory(mockParent).build();
 
         Product mockProduct = Product.builder()
                 .productId(1L)
                 .productName("갈색병 세럼 50ml")
                 .brand("에스티로더")
                 .price(new BigDecimal("89000"))
-                .parentCategory(mockCategory)
+                .childCategory(mockCategory)
                 .thumbnailUrl("https://allpick.com")
                 .optionList(new ArrayList<>())
                 .productImageList(new ArrayList<>())
@@ -259,15 +260,14 @@ class ProductServiceImplTest {
         Seller seller = Seller.builder()
                 .sellerId(sellerId)
                 .build();
-        ParentCategory category = ParentCategory.builder()
-                .categoryName("뷰티")
-                .build();
+        ParentCategory mockParent = ParentCategory.builder().categoryName("뷰티").build();
+        ChildCategory category = ChildCategory.builder().categoryName("스킨케어").parentCategory(mockParent).build();
         Product pendingProduct = Product.builder()
                 .productId(1L)
                 .productName("승인 대기 상품")
                 .brand("올픽")
                 .price(new BigDecimal("10000"))
-                .parentCategory(category)
+                .childCategory(category)
                 .thumbnailUrl("https://allpick.com/pending.jpg")
                 .approvalStatus(Product.ApprovalStatus.PENDING)
                 .build();
@@ -276,7 +276,7 @@ class ProductServiceImplTest {
                 .productName("거절 상품")
                 .brand("올픽")
                 .price(new BigDecimal("20000"))
-                .parentCategory(category)
+                .childCategory(category)
                 .thumbnailUrl("https://allpick.com/rejected.jpg")
                 .approvalStatus(Product.ApprovalStatus.REJECTED)
                 .build();


### PR DESCRIPTION
## 개요
- 상품이 자식 카테고리를 직접 참조하도록 변경하여 자식 카테고리별 상품 필터링 지원
---

## 작업 내용
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller: 
  없음
- Service: 
상품 등록 시 parentCategoryRepository → childCategoryRepository로 변경, ChildCategory를 통해 Product 생성

- Repository: 
ProductRepository EntityGraph 및 JPQL 쿼리를 childCategory → parentCategory 조인 구조로 수정

- 기타: 
Product 엔티티의 parentCategory FK → childCategory FK로 변경, 관련 DTO(ProductListResponseDto, ProductDetailResponseDto, SellerProductListResponseDto, AdminProductListResponseDto) parentCategoryName 조회 경로 수정 (child → parent 탐색), 테스트 코드 반영

---

## 관련 이슈
- 관련 이슈: 없음

---

## 변경 전 / 후
### Before
- products 테이블이 parent_category_id만 참조하여 자식 카테고리 구분 불가
- 자식 카테고리(상의/하의/신발/가방 등) 클릭 시 같은 상품만 노출되는 버그 존재

### After
- products 테이블이 child_category_id를 직접 참조
- childCategory → parentCategory 탐색으로 기존 parentCategoryName 반환 유지
- 자식 카테고리별 상품 필터링 정상 동작