### PR TITLE
fix: 관리자·판매자 문의 조회 시 첨부파일 누락 및 S3 URL 리전 오류 수정

### DIFF
--- a/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/admin/product/service/impl/InquiryServiceImpl.java
@@ -121,7 +121,8 @@ public class InquiryServiceImpl implements InquiryService {
                         inquiry,
                         inquiryAnswerRepository.findByInquiryId(inquiry.getInquiryId())
                                 .stream().map(InquiryAnswerResponseDto::from).toList(),
-                        List.of()
+                        attachmentRepository.findByInquiryIdAndDeletedAtIsNull(inquiry.getInquiryId())
+                                .stream().map(AttachmentResponseDto::from).toList()
                 ))
                 .toList();
     }
@@ -144,7 +145,8 @@ public class InquiryServiceImpl implements InquiryService {
                         inquiry,
                         inquiryAnswerRepository.findByInquiryId(inquiry.getInquiryId())
                                 .stream().map(InquiryAnswerResponseDto::from).toList(),
-                        List.of()
+                        attachmentRepository.findByInquiryIdAndDeletedAtIsNull(inquiry.getInquiryId())
+                                .stream().map(AttachmentResponseDto::from).toList()
                 ))
                 .toList();
     }

--- a/src/main/java/co/kr/allpick/global/config/S3Properties.java
+++ b/src/main/java/co/kr/allpick/global/config/S3Properties.java
@@ -11,4 +11,5 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "cloud.aws.s3")
 public class S3Properties {
     private String imageBucket;
+    private String region;
 }

--- a/src/main/java/co/kr/allpick/global/util/S3Uploader.java
+++ b/src/main/java/co/kr/allpick/global/util/S3Uploader.java
@@ -6,6 +6,7 @@ import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -24,6 +25,9 @@ public class S3Uploader {
 
     private final S3Client s3Client;
     private final S3Properties s3Properties;
+
+    @Value("${spring.cloud.aws.s3.region}")
+    private String region;
 
     /**
      * 이미지 업로드
@@ -97,7 +101,7 @@ public class S3Uploader {
 
     private String buildUrl(String fileName) {
         return "https://" + s3Properties.getImageBucket()
-                + ".s3.amazonaws.com/" + fileName;
+                + ".s3." + region + ".amazonaws.com/" + fileName;
     }
 
     private String extractFileName(String imageUrl) {

--- a/src/main/java/co/kr/allpick/global/util/S3Uploader.java
+++ b/src/main/java/co/kr/allpick/global/util/S3Uploader.java
@@ -6,7 +6,6 @@ import co.kr.allpick.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -25,9 +24,6 @@ public class S3Uploader {
 
     private final S3Client s3Client;
     private final S3Properties s3Properties;
-
-    @Value("${spring.cloud.aws.s3.region}")
-    private String region;
 
     /**
      * 이미지 업로드
@@ -101,7 +97,7 @@ public class S3Uploader {
 
     private String buildUrl(String fileName) {
         return "https://" + s3Properties.getImageBucket()
-                + ".s3." + region + ".amazonaws.com/" + fileName;
+                + ".s3." + s3Properties.getRegion() + ".amazonaws.com/" + fileName;
     }
 
     private String extractFileName(String imageUrl) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.data.redis.port=6379
 spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 spring.cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 cloud.aws.s3.image-bucket=${S3_IMAGE_BUCKET_NAME}
+cloud.aws.s3.region=ap-southeast-2
 
 # CoolSMS
 coolsms.api-key=${COOLSMS_API_KEY}


### PR DESCRIPTION
## 개요
- 관리자·판매자 문의 목록 조회 시 첨부파일이 항상 빈 배열로 반환되는 버그 수정 및 S3 이미지 URL 리전 누락 수정
---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller: 없음
- Service: InquiryServiceImpl - getAllInquiries, getSellerInquiries에서 attachments List.of() 하드코딩 → 실제 DB 조회로 변경
- Repository: 없음
- 기타: S3Uploader - buildUrl에 리전 포함하도록 수정 (s3.amazonaws.com → s3.{region}.amazonaws.com)

---

## 관련 이슈
-  없음

---

## 변경 전 / 후
### Before
- getAllInquiries, getSellerInquiries에서 attachments를 List.of()로 하드코딩하여 관리자·판매자가 문의 목록 조회 시 첨부파일이 항상 빈 배열로 반환됨
- S3 버킷 리전이 ap-southeast-2임에도 URL에 리전이 없어 (s3.amazonaws.com) 이미지 로드 실패 가능성 존재

### After
- 문의 목록 조회 시 attachmentRepository에서 실제 첨부파일을 조회하여 반환
- S3 URL에 리전 포함 (s3.ap-southeast-2.amazonaws.com) 으로 이미지 정상 로드