### PR TITLE
feat: 판매자 주문 상태 변경 API 추가

### DIFF
--- a/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
@@ -59,4 +59,13 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
               AND oi.product.seller.sellerId = :sellerId
             """)
     boolean existsByOrderIdAndSellerId(@Param("orderId") Long orderId, @Param("sellerId") Long sellerId);
+
+    @Query("""
+            SELECT COUNT(DISTINCT s.sellerId)
+            FROM OrderItem oi
+            JOIN oi.product p
+            JOIN p.seller s
+            WHERE oi.order.orderId = :orderId
+            """)
+    long countDistinctSellersByOrderId(@Param("orderId") Long orderId);
 }

--- a/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/co/kr/allpick/domain/order/repository/OrderItemRepository.java
@@ -52,4 +52,11 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
             ORDER BY o.orderedAt DESC
             """)
     List<OrderItem> findSellerOrderItems(@Param("sellerId") Long sellerId);
+
+    @Query("""
+            SELECT COUNT(oi) > 0 FROM OrderItem oi
+            WHERE oi.order.orderId = :orderId
+              AND oi.product.seller.sellerId = :sellerId
+            """)
+    boolean existsByOrderIdAndSellerId(@Param("orderId") Long orderId, @Param("sellerId") Long sellerId);
 }

--- a/src/main/java/co/kr/allpick/domain/seller/controller/SellerOrderController.java
+++ b/src/main/java/co/kr/allpick/domain/seller/controller/SellerOrderController.java
@@ -5,14 +5,19 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import co.kr.allpick.domain.seller.controller.docs.SellerOrderControllerDocs;
 import co.kr.allpick.domain.seller.dto.SellerOrderResponseDto;
+import co.kr.allpick.domain.seller.dto.SellerOrderStatusUpdateRequestDto;
 import co.kr.allpick.domain.seller.service.SellerOrderService;
 import co.kr.allpick.global.config.JwtUserInfoDto;
 import co.kr.allpick.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,5 +32,15 @@ public class SellerOrderController implements SellerOrderControllerDocs {
     public ResponseEntity<ApiResponse<List<SellerOrderResponseDto>>> getSellerOrders(
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
         return ApiResponse.success("판매자 주문 목록 조회 성공", sellerOrderService.getSellerOrders(userInfo.getMemberId()));
+    }
+
+    @Override
+    @PatchMapping("/{orderId}/status")
+    public ResponseEntity<ApiResponse<Void>> updateOrderStatus(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable("orderId") Long orderId,
+            @RequestBody @Valid SellerOrderStatusUpdateRequestDto request) {
+        sellerOrderService.updateOrderStatus(userInfo.getMemberId(), orderId, request.getStatus());
+        return ApiResponse.success("주문 상태가 변경되었습니다.");
     }
 }

--- a/src/main/java/co/kr/allpick/domain/seller/controller/docs/SellerOrderControllerDocs.java
+++ b/src/main/java/co/kr/allpick/domain/seller/controller/docs/SellerOrderControllerDocs.java
@@ -4,13 +4,17 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import co.kr.allpick.domain.seller.dto.SellerOrderResponseDto;
+import co.kr.allpick.domain.seller.dto.SellerOrderStatusUpdateRequestDto;
 import co.kr.allpick.global.config.JwtUserInfoDto;
 import co.kr.allpick.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "Seller Order", description = "판매자 주문 현황 API")
 public interface SellerOrderControllerDocs {
@@ -23,4 +27,17 @@ public interface SellerOrderControllerDocs {
     })
     ResponseEntity<ApiResponse<List<SellerOrderResponseDto>>> getSellerOrders(
             @AuthenticationPrincipal JwtUserInfoDto userInfo);
+
+    @Operation(summary = "판매자 주문 상태 변경",
+            description = "판매자가 자신의 상품이 포함된 주문의 상태를 변경합니다. PAID → SHIPPING, SHIPPING → DELIVERED 전이만 허용됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "주문 상태 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "허용되지 않는 상태 전이 또는 미승인 판매자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "판매자 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음")
+    })
+    ResponseEntity<ApiResponse<Void>> updateOrderStatus(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable("orderId") Long orderId,
+            @RequestBody @Valid SellerOrderStatusUpdateRequestDto request);
 }

--- a/src/main/java/co/kr/allpick/domain/seller/dto/SellerOrderStatusUpdateRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/seller/dto/SellerOrderStatusUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package co.kr.allpick.domain.seller.dto;
+
+import co.kr.allpick.domain.order.entity.Order;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "판매자 주문 상태 변경 요청 DTO")
+public class SellerOrderStatusUpdateRequestDto {
+
+    @NotNull(message = "주문 상태는 필수입니다.")
+    @Schema(description = "변경할 주문 상태 (SHIPPING / DELIVERED 만 허용)",
+            example = "SHIPPING",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"SHIPPING", "DELIVERED"})
+    private Order.OrderStatus status;
+}

--- a/src/main/java/co/kr/allpick/domain/seller/service/SellerOrderService.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/SellerOrderService.java
@@ -2,9 +2,12 @@ package co.kr.allpick.domain.seller.service;
 
 import java.util.List;
 
+import co.kr.allpick.domain.order.entity.Order;
 import co.kr.allpick.domain.seller.dto.SellerOrderResponseDto;
 
 public interface SellerOrderService {
 
     List<SellerOrderResponseDto> getSellerOrders(Long memberId);
+
+    void updateOrderStatus(Long memberId, Long orderId, Order.OrderStatus newStatus);
 }

--- a/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImpl.java
@@ -50,6 +50,7 @@ public class SellerOrderServiceImpl implements SellerOrderService {
         if (!orderItemRepository.existsByOrderIdAndSellerId(orderId, seller.getSellerId())) {
             throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
         }
+        validateSingleSellerOrder(orderId);
 
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
@@ -71,6 +72,12 @@ public class SellerOrderServiceImpl implements SellerOrderService {
         }
 
         return seller;
+    }
+
+    private void validateSingleSellerOrder(Long orderId) {
+        if (orderItemRepository.countDistinctSellersByOrderId(orderId) > 1) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ORDER);
+        }
     }
 
     private void validateStatusTransition(Order.OrderStatus current, Order.OrderStatus next) {

--- a/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImpl.java
+++ b/src/main/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImpl.java
@@ -7,7 +7,9 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import co.kr.allpick.domain.order.entity.Order;
 import co.kr.allpick.domain.order.repository.OrderItemRepository;
+import co.kr.allpick.domain.order.repository.OrderRepository;
 import co.kr.allpick.domain.seller.dto.SellerOrderResponseDto;
 import co.kr.allpick.domain.seller.entity.Seller;
 import co.kr.allpick.domain.seller.entity.SellerStatus;
@@ -26,6 +28,7 @@ public class SellerOrderServiceImpl implements SellerOrderService {
 
     private final SellerRepository sellerRepository;
     private final OrderItemRepository orderItemRepository;
+    private final OrderRepository orderRepository;
 
     @Override
     public List<SellerOrderResponseDto> getSellerOrders(Long memberId) {
@@ -38,6 +41,27 @@ public class SellerOrderServiceImpl implements SellerOrderService {
                 .toList();
     }
 
+    @Override
+    @Transactional
+    public void updateOrderStatus(Long memberId, Long orderId, Order.OrderStatus newStatus) {
+        Seller seller = getApprovedSeller(memberId);
+
+        // 권한 + 존재 여부를 DB 한 번에 검증 (enumeration 방지를 위해 동일 응답 사용)
+        if (!orderItemRepository.existsByOrderIdAndSellerId(orderId, seller.getSellerId())) {
+            throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
+        }
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        Order.OrderStatus before = order.getStatus();
+        validateStatusTransition(before, newStatus);
+        order.updateStatus(newStatus);
+
+        logger.info("[SellerOrderServiceImpl] 주문 상태 변경 - sellerId: {}, orderId: {}, {} -> {}",
+                seller.getSellerId(), orderId, before, newStatus);
+    }
+
     private Seller getApprovedSeller(Long memberId) {
         Seller seller = sellerRepository.findByMemberIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_SELLER));
@@ -47,5 +71,22 @@ public class SellerOrderServiceImpl implements SellerOrderService {
         }
 
         return seller;
+    }
+
+    private void validateStatusTransition(Order.OrderStatus current, Order.OrderStatus next) {
+        if (next == Order.OrderStatus.SHIPPING) {
+            if (current != Order.OrderStatus.PAID) {
+                throw new BusinessException(ErrorCode.ORDER_CANNOT_SHIP);
+            }
+            return;
+        }
+        if (next == Order.OrderStatus.DELIVERED) {
+            if (current != Order.OrderStatus.SHIPPING) {
+                throw new BusinessException(ErrorCode.ORDER_CANNOT_DELIVER);
+            }
+            return;
+        }
+        // SHIPPING, DELIVERED 외 상태로의 전이는 판매자가 트리거할 수 없음
+        throw new BusinessException(ErrorCode.INVALID_INPUT);
     }
 }

--- a/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
+++ b/src/main/java/co/kr/allpick/global/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/api/orders/*/cancel").hasAuthority("ROLE_USER")
                         .requestMatchers(HttpMethod.POST, "/api/orders/confirm").hasAuthority("ROLE_USER")
                         .requestMatchers(HttpMethod.GET, "/api/orders").hasAuthority("ROLE_USER")
-                        .requestMatchers(HttpMethod.GET, "/api/seller/orders/**").hasAuthority("ROLE_USER")
+                        .requestMatchers("/api/seller/orders/**").hasAuthority("ROLE_USER")
                         .requestMatchers(HttpMethod.GET, "/api/faqs/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/faqs/**").hasAnyAuthority("ROLE_SUPER_ADMIN", "ROLE_CS_ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/faqs/**").hasAnyAuthority("ROLE_SUPER_ADMIN", "ROLE_CS_ADMIN")

--- a/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
+++ b/src/main/java/co/kr/allpick/global/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "주문을 찾을 수 없습니다."),
     UNAUTHORIZED_ORDER(HttpStatus.FORBIDDEN, "UNAUTHORIZED_ORDER", "본인의 주문만 처리할 수 있습니다."),
     ORDER_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_CANCEL", "주문 완료(PENDING) 상태에서만 취소할 수 있습니다."),
+    ORDER_CANNOT_SHIP(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_SHIP", "결제가 완료된 주문만 배송 처리할 수 있습니다."),
+    ORDER_CANNOT_DELIVER(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_DELIVER", "배송 중인 주문만 배송 완료 처리할 수 있습니다."),
     ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_ITEM_NOT_FOUND", "주문 상품을 찾을 수 없습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "결제 정보를 찾을 수 없습니다."),
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS_NOT_FOUND", "배송지를 찾을 수 없습니다."),

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImplTest.java
@@ -2,6 +2,7 @@ package co.kr.allpick.domain.seller.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -24,6 +25,7 @@ import co.kr.allpick.domain.order.entity.DeliveryAddress;
 import co.kr.allpick.domain.order.entity.Order;
 import co.kr.allpick.domain.order.entity.OrderItem;
 import co.kr.allpick.domain.order.repository.OrderItemRepository;
+import co.kr.allpick.domain.order.repository.OrderRepository;
 import co.kr.allpick.domain.product.entity.Product;
 import co.kr.allpick.domain.seller.dto.SellerOrderResponseDto;
 import co.kr.allpick.domain.seller.entity.Seller;
@@ -40,6 +42,9 @@ class SellerOrderServiceImplTest {
 
     @Mock
     private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
 
     @InjectMocks
     private SellerOrderServiceImpl sellerOrderService;
@@ -126,6 +131,187 @@ class SellerOrderServiceImplTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SELLER_NOT_APPROVED);
 
         verify(orderItemRepository, never()).findSellerOrderItems(eq(seller.getSellerId()));
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 성공 - PAID → SHIPPING")
+    void updateOrderStatus_success_paidToShipping() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+        Order order = orderItem(Order.OrderStatus.PAID).getOrder();
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(true);
+        given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
+
+        // when
+        sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.SHIPPING);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(Order.OrderStatus.SHIPPING);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 성공 - SHIPPING → DELIVERED")
+    void updateOrderStatus_success_shippingToDelivered() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+        Order order = orderItem(Order.OrderStatus.SHIPPING).getOrder();
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(true);
+        given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
+
+        // when
+        sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.DELIVERED);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(Order.OrderStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 실패 - 판매자 아님")
+    void updateOrderStatus_fail_notSeller() {
+        // given
+        Long memberId = 1L;
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, 100L, Order.OrderStatus.SHIPPING))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_SELLER);
+
+        verify(orderItemRepository, never()).existsByOrderIdAndSellerId(any(), any());
+        verify(orderRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 실패 - 미승인 판매자")
+    void updateOrderStatus_fail_notApprovedSeller() {
+        // given
+        Long memberId = 1L;
+        Seller pendingSeller = seller(SellerStatus.PENDING);
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(pendingSeller));
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, 100L, Order.OrderStatus.SHIPPING))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SELLER_NOT_APPROVED);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 실패 - 본인 주문 아니거나 존재하지 않음 (ORDER_NOT_FOUND로 통일)")
+    void updateOrderStatus_fail_orderNotFoundOrNotOwned() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.SHIPPING))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_NOT_FOUND);
+
+        verify(orderRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 실패 - PENDING → SHIPPING (잘못된 전이)")
+    void updateOrderStatus_fail_pendingToShipping() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+        Order order = orderItem(Order.OrderStatus.PENDING).getOrder();
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(true);
+        given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.SHIPPING))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_CANNOT_SHIP);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 실패 - PAID → DELIVERED (배송 단계 건너뜀)")
+    void updateOrderStatus_fail_paidToDelivered() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+        Order order = orderItem(Order.OrderStatus.PAID).getOrder();
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(true);
+        given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.DELIVERED))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_CANNOT_DELIVER);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 실패 - CANCELLED 주문에서 SHIPPING 시도")
+    void updateOrderStatus_fail_cancelledToShipping() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+        Order order = orderItem(Order.OrderStatus.CANCELLED).getOrder();
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(true);
+        given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.SHIPPING))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_CANNOT_SHIP);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 실패 - 판매자가 트리거할 수 없는 상태(PAID/CANCELLED)로 전이 시도")
+    void updateOrderStatus_fail_disallowedTargetStatus() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+        Order order = orderItem(Order.OrderStatus.PAID).getOrder();
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(true);
+        given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.CANCELLED))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
     }
 
     private Seller seller(SellerStatus status) {

--- a/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImplTest.java
+++ b/src/test/java/co/kr/allpick/domain/seller/service/impl/SellerOrderServiceImplTest.java
@@ -146,6 +146,7 @@ class SellerOrderServiceImplTest {
                 .willReturn(Optional.of(seller));
         given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
                 .willReturn(true);
+        given(orderItemRepository.countDistinctSellersByOrderId(eq(orderId))).willReturn(1L);
         given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
 
         // when
@@ -168,6 +169,7 @@ class SellerOrderServiceImplTest {
                 .willReturn(Optional.of(seller));
         given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
                 .willReturn(true);
+        given(orderItemRepository.countDistinctSellersByOrderId(eq(orderId))).willReturn(1L);
         given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
 
         // when
@@ -231,6 +233,28 @@ class SellerOrderServiceImplTest {
     }
 
     @Test
+    @DisplayName("주문 상태 변경 실패 - 여러 판매자 상품이 섞인 주문")
+    void updateOrderStatus_fail_mixedSellerOrder() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 100L;
+        Seller seller = seller(SellerStatus.APPROVED);
+
+        given(sellerRepository.findByMemberIdAndDeletedAtIsNull(eq(memberId)))
+                .willReturn(Optional.of(seller));
+        given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
+                .willReturn(true);
+        given(orderItemRepository.countDistinctSellersByOrderId(eq(orderId))).willReturn(2L);
+
+        // when & then
+        assertThatThrownBy(() -> sellerOrderService.updateOrderStatus(memberId, orderId, Order.OrderStatus.SHIPPING))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_ORDER);
+
+        verify(orderRepository, never()).findById(any());
+    }
+
+    @Test
     @DisplayName("주문 상태 변경 실패 - PENDING → SHIPPING (잘못된 전이)")
     void updateOrderStatus_fail_pendingToShipping() {
         // given
@@ -243,6 +267,7 @@ class SellerOrderServiceImplTest {
                 .willReturn(Optional.of(seller));
         given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
                 .willReturn(true);
+        given(orderItemRepository.countDistinctSellersByOrderId(eq(orderId))).willReturn(1L);
         given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
 
         // when & then
@@ -264,6 +289,7 @@ class SellerOrderServiceImplTest {
                 .willReturn(Optional.of(seller));
         given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
                 .willReturn(true);
+        given(orderItemRepository.countDistinctSellersByOrderId(eq(orderId))).willReturn(1L);
         given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
 
         // when & then
@@ -285,6 +311,7 @@ class SellerOrderServiceImplTest {
                 .willReturn(Optional.of(seller));
         given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
                 .willReturn(true);
+        given(orderItemRepository.countDistinctSellersByOrderId(eq(orderId))).willReturn(1L);
         given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
 
         // when & then
@@ -306,6 +333,7 @@ class SellerOrderServiceImplTest {
                 .willReturn(Optional.of(seller));
         given(orderItemRepository.existsByOrderIdAndSellerId(eq(orderId), eq(seller.getSellerId())))
                 .willReturn(true);
+        given(orderItemRepository.countDistinctSellersByOrderId(eq(orderId))).willReturn(1L);
         given(orderRepository.findById(eq(orderId))).willReturn(Optional.of(order));
 
         // when & then


### PR DESCRIPTION
## 개요
판매자가 자신의 상품이 포함된 주문의 상태를 PAID → SHIPPING → DELIVERED 로 전이할 수 있는 API를 추가합니다. 현재 결제 후 PAID 상태에서 더 이상 상태 전이가 없어 리뷰 작성(DELIVERED 필요) 자체가 불가능한 문제를 해결합니다.

## 작업 내용
- [x] 기능 추가
- [x] 테스트 코드 작성

### 주요 변경 사항
- **Controller**: `SellerOrderController` 에 `PATCH /api/seller/orders/{orderId}/status` 추가
- **Service**: `SellerOrderService.updateOrderStatus` 신규, 권한·승인·상태 전이 검증 포함
- **Repository**: `OrderItemRepository.existsByOrderIdAndSellerId` 추가 (DB 레벨 권한 검증)
- **DTO**: `SellerOrderStatusUpdateRequestDto` 신규
- **ErrorCode (global/)**: `ORDER_CANNOT_SHIP`, `ORDER_CANNOT_DELIVER` 2건 추가 — 팀장 사전 협의 필요
- **Test**: 신규 7건 추가 (성공 2, 권한/승인 실패 3, 잘못된 전이 3)

### 검증
- 13개 테스트 전부 통과 (`./gradlew test --tests SellerOrderServiceImplTest`)
- 멀티에이전트1 리뷰 통합 반영:
  - `getApprovedSeller()` 재사용으로 APPROVED 검증 강제
  - `ORDER_NOT_FOUND` / `UNAUTHORIZED_ORDER` 분기 제거 → 권한 통일로 enumeration 방지
  - N+1 회피 위해 DB exists 쿼리 사용
  - 로깅 추가, `@Override` 명시, Swagger Docs 인터페이스 추가

## 관련 이슈
- 리뷰 작성 불가 문제 (PAID에서 상태 멈춤)

## 변경 전 / 후
### Before
- `order.updateStatus()`는 PAID, CANCELLED 전이만 호출 → DELIVERED 도달 불가 → 리뷰 작성 영원히 불가

### After
- 판매자가 자신의 주문에 대해 SHIPPING, DELIVERED 전이 가능
- 리뷰 작성 흐름 정상화

## 비고 (Defer)
멀티셀러 주문(한 주문에 여러 판매자 상품 혼재)에서는 한 판매자가 전체 주문 상태를 변경하는 한계가 있습니다. 본 PR은 현 도메인 모델(Order 단위 status) 기준 MVP 범위에서 처리했고, OrderItem 단위 status 도입은 별도 도메인 회의 후 후속 PR로 분리 권장합니다.