### PR TITLE
fix: 옵션 없는 상품 후기 등록 허용

### DIFF
--- a/src/main/java/co/kr/allpick/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/co/kr/allpick/domain/review/dto/ReviewRequestDto.java
@@ -29,7 +29,7 @@ public class ReviewRequestDto {
     
     private String content;
     
-    @NotBlank @Schema(description = "선택한 옵션값", example = "1", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "선택한 옵션값", example = "270")
     private String selectedOption; 
 }
 


### PR DESCRIPTION
﻿## 개요
- 옵션이 없는 상품도 후기 등록이 가능하도록 리뷰 요청 DTO 검증을 보완했습니다.

---

## 작업 내용
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 코드 작성
- [ ] 문서 수정

### 주요 변경 사항
- Controller: 해당 없음
- Service: 해당 없음
- Repository: 해당 없음
- 기타:
  - `ReviewRequestDto.selectedOption` 필수 검증 제거
  - 옵션 없는 주문 상품도 `POST /api/reviews` 요청을 통과할 수 있도록 보완

---

## 관련 이슈
- 관련 이슈: s4ngg/AP-React#91

---

## 변경 전 / 후
### Before
- 리뷰 요청에서 `selectedOption`이 필수라 옵션 없는 상품은 후기 등록 시 validation 실패 가능성이 있었습니다.

### After
- `selectedOption`은 선택값으로 처리되어 옵션 없는 상품도 후기 등록이 가능합니다.

---

## 검증
- `./gradlew.bat compileJava --rerun-tasks`
- `./gradlew.bat test --tests "co.kr.allpick.domain.review.service.impl.ReviewServiceImplTest"`
